### PR TITLE
Add a Travis.ci build descriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+compiler:
+  - clang
+  - gcc
+sudo: false
+addons:
+  apt:
+    packages:
+      - valgrind
+script: make -C c check


### PR DESCRIPTION
Eventually, when we have more language implementations, this will need to be more complex.  But for now, this does the job.