### PR TITLE
Add Dockerfile for building C host

### DIFF
--- a/docker/build-c/Dockerfile
+++ b/docker/build-c/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:trusty
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    valgrind \
+ && apt-get clean
+
+RUN useradd -m swanson
+
+USER swanson
+ENV HOME /home/swanson
+WORKDIR /home/swanson
+CMD ["/bin/bash"]


### PR DESCRIPTION
This Dockerfile installs the C compiler and valgrind, which gives us everything we need to build and test the C host.