### PR TITLE
[c] Verify that names aren't already in input sets

### DIFF
--- a/c/Makefile.deps
+++ b/c/Makefile.deps
@@ -8,6 +8,8 @@ $(BUILD_ROOT)/objs/libswanson/yaml.o: \
  $(SOURCE_ROOT)/include/swanson.h \
  $(SOURCE_ROOT)/ccan/likely/likely.h \
  $(SOURCE_ROOT)/include/config.h \
+ $(SOURCE_ROOT)/ccan/str/str.h \
+ $(SOURCE_ROOT)/ccan/str/str_debug.h \
  $(SOURCE_ROOT)/yaml/include/yaml.h
 $(BUILD_ROOT)/objs/yaml/src/api.o: \
  $(SOURCE_ROOT)/yaml/src/api.c \

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -33,6 +33,9 @@ void
 s0_name_free(struct s0_name *);
 
 const char *
+s0_name_human_readable(const struct s0_name *);
+
+const char *
 s0_name_content(const struct s0_name *);
 
 size_t
@@ -104,6 +107,11 @@ s0_name_mapping_at(const struct s0_name_mapping *, size_t index);
 /* Returns NULL if from is not in the mapping's domain. */
 struct s0_name *
 s0_name_mapping_get(const struct s0_name_mapping *, const struct s0_name *from);
+
+/* Returns NULL if from is not in the mapping's range. */
+struct s0_name *
+s0_name_mapping_get_from(const struct s0_name_mapping *,
+                         const struct s0_name *to);
 
 
 /*-----------------------------------------------------------------------------

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -28,12 +28,13 @@ s0_name_new(size_t size, const void *content)
         return NULL;
     }
     name->size = size;
-    name->content = malloc(size);
+    name->content = malloc(size + 1);
     if (unlikely(name->content == NULL)) {
         free(name);
         return NULL;
     }
     memcpy((void *) name->content, content, size);
+    ((char *) name->content)[size] = '\0';
     return name;
 }
 
@@ -48,6 +49,13 @@ s0_name_free(struct s0_name *name)
 {
     free((void *) name->content);
     free(name);
+}
+
+const char *
+s0_name_human_readable(const struct s0_name *name)
+{
+    /* TODO: Return something nicer for binary content. */
+    return name->content;
 }
 
 const char *
@@ -243,6 +251,19 @@ s0_name_mapping_get(const struct s0_name_mapping *mapping,
     for (i = 0; i < mapping->size; i++) {
         if (s0_name_eq(mapping->entries[i].from, from)) {
             return mapping->entries[i].to;
+        }
+    }
+    return NULL;
+}
+
+struct s0_name *
+s0_name_mapping_get_from(const struct s0_name_mapping *mapping,
+                         const struct s0_name *to)
+{
+    size_t  i;
+    for (i = 0; i < mapping->size; i++) {
+        if (s0_name_eq(mapping->entries[i].to, to)) {
+            return mapping->entries[i].from;
         }
     }
     return NULL;

--- a/tests/s0/parsing/inputs.yaml
+++ b/tests/s0/parsing/inputs.yaml
@@ -37,36 +37,34 @@ module:
     src: exit
     branch: call
 
-# TODO
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: There cannot be multiple inputs with the same "from" name
-# module:
-#   inputs:
-#     a: b
-#     a: c
-#   statements: []
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
-# error: >
-#   There is already an input named `a`.
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple inputs with the same "from" name
+module:
+  inputs:
+    a: b
+    a: c
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
+error: >
+  There is already an input named `a`.
 
-# TODO
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: There cannot be multiple inputs with the same "to" name
-# module:
-#   inputs:
-#     a: c
-#     b: c
-#   statements: []
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
-# error: >
-#   There is already an input that is renamed to `c`.
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple inputs with the same "to" name
+module:
+  inputs:
+    a: c
+    b: c
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
+error: >
+  There is already an input that is renamed to `c`.


### PR DESCRIPTION
There can't be any duplicate names in the domain or range of a block's input mapping.  The C bindings now verify this.

Bug: https://forum.swanson-lang.org/t/c-host-does-not-verify-contents-of-input-set/19/1