### PR TITLE
C host should verify environment contents when parsing statements

### DIFF
--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -82,10 +82,12 @@ s0_name_set_at(const struct s0_name_set *, size_t index);
  */
 
 struct s0_name_mapping;
+struct s0_entity_type;
 
 struct s0_name_mapping_entry {
     struct s0_name  *from;
     struct s0_name  *to;
+    struct s0_entity_type  *type;
 };
 
 struct s0_name_mapping *
@@ -94,28 +96,28 @@ s0_name_mapping_new(void);
 void
 s0_name_mapping_free(struct s0_name_mapping *);
 
-/* Takes ownership of from and to.  from MUST not already be present in the
- * mapping's domain, and to MUST not already be present in the mapping's range.
- * Returns 0 if name was added; -1 if we couldn't allocate space for the new
- * entry. */
+/* Takes ownership of from, to, and type.  from MUST not already be present in
+ * the mapping's domain, and to MUST not already be present in the mapping's
+ * range.  Returns 0 if name was added; -1 if we couldn't allocate space for the
+ * new entry. */
 int
 s0_name_mapping_add(struct s0_name_mapping *, struct s0_name *from,
-                    struct s0_name *to);
+                    struct s0_name *to, struct s0_entity_type *type);
 
 size_t
 s0_name_mapping_size(const struct s0_name_mapping *);
 
 /* Returns entries in order that they were added to the set.  index MUST be <
  * size of mapping.  Set still owns the names; you must not free it. */
-struct s0_name_mapping_entry
+const struct s0_name_mapping_entry *
 s0_name_mapping_at(const struct s0_name_mapping *, size_t index);
 
 /* Returns NULL if from is not in the mapping's domain. */
-struct s0_name *
+const struct s0_name_mapping_entry *
 s0_name_mapping_get(const struct s0_name_mapping *, const struct s0_name *from);
 
 /* Returns NULL if from is not in the mapping's range. */
-struct s0_name *
+const struct s0_name_mapping_entry *
 s0_name_mapping_get_from(const struct s0_name_mapping *,
                          const struct s0_name *to);
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -183,18 +183,18 @@ s0_named_blocks_get(const struct s0_named_blocks *, const struct s0_name *name);
 
 struct s0_statement;
 
-enum s0_statement_type {
-    S0_STATEMENT_TYPE_CREATE_ATOM,
-    S0_STATEMENT_TYPE_CREATE_CLOSURE,
-    S0_STATEMENT_TYPE_CREATE_LITERAL,
-    S0_STATEMENT_TYPE_CREATE_METHOD
+enum s0_statement_kind {
+    S0_STATEMENT_KIND_CREATE_ATOM,
+    S0_STATEMENT_KIND_CREATE_CLOSURE,
+    S0_STATEMENT_KIND_CREATE_LITERAL,
+    S0_STATEMENT_KIND_CREATE_METHOD
 };
 
 void
 s0_statement_free(struct s0_statement *);
 
-enum s0_statement_type
-s0_statement_type(const struct s0_statement *);
+enum s0_statement_kind
+s0_statement_kind(const struct s0_statement *);
 
 
 /* Takes control of dest */
@@ -291,16 +291,16 @@ s0_statement_list_at(const struct s0_statement_list *, size_t index);
 
 struct s0_invocation;
 
-enum s0_invocation_type {
-    S0_INVOCATION_TYPE_INVOKE_CLOSURE,
-    S0_INVOCATION_TYPE_INVOKE_METHOD
+enum s0_invocation_kind {
+    S0_INVOCATION_KIND_INVOKE_CLOSURE,
+    S0_INVOCATION_KIND_INVOKE_METHOD
 };
 
 void
 s0_invocation_free(struct s0_invocation *);
 
-enum s0_invocation_type
-s0_invocation_type(const struct s0_invocation *);
+enum s0_invocation_kind
+s0_invocation_kind(const struct s0_invocation *);
 
 
 /* Takes control of src and branch */
@@ -356,19 +356,19 @@ s0_block_invocation(const struct s0_block *);
  * S₀: Entities
  */
 
-enum s0_entity_type {
-    S0_ENTITY_TYPE_ATOM,
-    S0_ENTITY_TYPE_CLOSURE,
-    S0_ENTITY_TYPE_LITERAL,
-    S0_ENTITY_TYPE_METHOD,
-    S0_ENTITY_TYPE_OBJECT
+enum s0_entity_kind {
+    S0_ENTITY_KIND_ATOM,
+    S0_ENTITY_KIND_CLOSURE,
+    S0_ENTITY_KIND_LITERAL,
+    S0_ENTITY_KIND_METHOD,
+    S0_ENTITY_KIND_OBJECT
 };
 
 void
 s0_entity_free(struct s0_entity *);
 
-enum s0_entity_type
-s0_entity_type(const struct s0_entity *);
+enum s0_entity_kind
+s0_entity_kind(const struct s0_entity *);
 
 
 struct s0_entity *

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -539,6 +539,15 @@ s0_environment_type_extract(struct s0_environment_type *dest,
                             struct s0_environment_type *src,
                             const struct s0_name_set *set);
 
+/* Ensures that an environment type satisfies the prerequisites of `stmt`, and
+ * then updates the environment type based on what `stmt` would do.
+ *
+ * Returns 0 if the prereqs were satisfied and the type was updated
+ * successfully; returns -1 otherwise. */
+int
+s0_environment_type_add_statement(struct s0_environment_type *,
+                                  const struct s0_statement *stmt);
+
 /* Adds an entry to the environment type for each entry in a name mapping, using
  * the mapping entry's `from` name and `type`.  This type describes the
  * environment that the caller must provide when invoking a block.

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -527,6 +527,18 @@ struct s0_entity_type *
 s0_environment_type_delete(struct s0_environment_type *,
                            const struct s0_name *name);
 
+/* Extracts entries from `src`, moving them into `dest`.  The entries to extract
+ * are given by a name set.  This is used for closure sets when constructing a
+ * closure, since the entries described by the type are moved from the
+ * containing environment into the closure's environment.
+ *
+ * Returns 0 if all of the entries were created successfully; returns -1 if
+ * there is an error moving the entries. */
+int
+s0_environment_type_extract(struct s0_environment_type *dest,
+                            struct s0_environment_type *src,
+                            const struct s0_name_set *set);
+
 /* Adds an entry to the environment type for each entry in a name mapping, using
  * the mapping entry's `from` name and `type`.  This type describes the
  * environment that the caller must provide when invoking a block.

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -522,6 +522,11 @@ struct s0_entity_type *
 s0_environment_type_get(const struct s0_environment_type *,
                         const struct s0_name *name);
 
+/* Returns NULL if name is not in environment type. */
+struct s0_entity_type *
+s0_environment_type_delete(struct s0_environment_type *,
+                           const struct s0_name *name);
+
 /* Adds an entry to the environment type for each entry in a name mapping, using
  * the mapping entry's `from` name and `type`.  This type describes the
  * environment that the caller must provide when invoking a block.

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -452,6 +452,31 @@ s0_object_get(const struct s0_entity *, const struct s0_name *name);
 
 
 /*-----------------------------------------------------------------------------
+ * S₀: Entity types
+ */
+
+struct s0_entity_type;
+
+enum s0_entity_type_kind {
+    S0_ENTITY_TYPE_KIND_ANY
+};
+
+void
+s0_entity_type_free(struct s0_entity_type *);
+
+enum s0_entity_type_kind
+s0_entity_type_kind(const struct s0_entity_type *);
+
+bool
+s0_entity_type_satisfied_by(const struct s0_entity_type *,
+                            const struct s0_entity *);
+
+
+struct s0_entity_type *
+s0_any_entity_type_new(void);
+
+
+/*-----------------------------------------------------------------------------
  * S₀: YAML
  */
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -522,6 +522,31 @@ struct s0_entity_type *
 s0_environment_type_get(const struct s0_environment_type *,
                         const struct s0_name *name);
 
+/* Adds an entry to the environment type for each entry in a name mapping, using
+ * the mapping entry's `from` name and `type`.  This type describes the
+ * environment that the caller must provide when invoking a block.
+ *
+ * Returns 0 if all of the entries were created successfully; returns -1 if
+ * there is an error creating the environment type. */
+int
+s0_environment_type_add_external_inputs(struct s0_environment_type *,
+                                        const struct s0_name_mapping *inputs);
+
+/* Adds an entry to the environment type for each entry in a name mapping, using
+ * the mapping entry's `to` name and `type`.  This type describes the
+ * environment a block is given when it first starts executing.
+ *
+ * You should have already filled in the environment type with entries
+ * representing any closure set that the block will operate under (to ensure
+ * that there are no name clashes between the closure set and the input
+ * mapping).
+ *
+ * Returns 0 if all of the entries were created successfully; returns -1 if
+ * there is an error creating the environment type. */
+int
+s0_environment_type_add_internal_inputs(struct s0_environment_type *,
+                                        const struct s0_name_mapping *inputs);
+
 bool
 s0_environment_type_satisfied_by(const struct s0_environment_type *,
                                  const struct s0_environment *);

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -464,6 +464,9 @@ enum s0_entity_type_kind {
     S0_ENTITY_TYPE_KIND_ANY
 };
 
+struct s0_entity_type *
+s0_entity_type_new_copy(const struct s0_entity_type *other);
+
 void
 s0_entity_type_free(struct s0_entity_type *);
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -477,6 +477,49 @@ s0_any_entity_type_new(void);
 
 
 /*-----------------------------------------------------------------------------
+ * S₀: Environment types
+ */
+
+struct s0_environment_type;
+
+struct s0_environment_type_entry {
+    struct s0_name  *name;
+    struct s0_entity_type  *type;
+};
+
+struct s0_environment_type *
+s0_environment_type_new(void);
+
+void
+s0_environment_type_free(struct s0_environment_type *);
+
+/* Takes ownership of name and type.  name MUST not already be present in
+ * environment type.  Returns 0 if name was added; -1 if we couldn't allocate
+ * space for the new entry. */
+int
+s0_environment_type_add(struct s0_environment_type *,
+                        struct s0_name *name, struct s0_entity_type *type);
+
+size_t
+s0_environment_type_size(const struct s0_environment_type *);
+
+/* Returns entries in order that they were added to the set.  index MUST be <
+ * size of environment_type.  Set still owns the name and entity type; you must
+ * not free them. */
+struct s0_environment_type_entry
+s0_environment_type_at(const struct s0_environment_type *, size_t index);
+
+/* Returns NULL if name is not in environment type. */
+struct s0_entity_type *
+s0_environment_type_get(const struct s0_environment_type *,
+                        const struct s0_name *name);
+
+bool
+s0_environment_type_satisfied_by(const struct s0_environment_type *,
+                                 const struct s0_environment *);
+
+
+/*-----------------------------------------------------------------------------
  * S₀: YAML
  */
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -29,6 +29,9 @@ s0_name_new(size_t size, const void *content);
 struct s0_name *
 s0_name_new_str(const void *content);
 
+struct s0_name *
+s0_name_new_copy(const struct s0_name *other);
+
 void
 s0_name_free(struct s0_name *);
 

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -553,7 +553,7 @@ s0_named_blocks_get(const struct s0_named_blocks *blocks,
  */
 
 struct s0_statement {
-    enum s0_statement_type  type;
+    enum s0_statement_kind  type;
     union {
         struct {
             struct s0_name  *dest;
@@ -585,7 +585,7 @@ s0_create_atom_new(struct s0_name *dest)
         s0_name_free(dest);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_TYPE_CREATE_ATOM;
+    stmt->type = S0_STATEMENT_KIND_CREATE_ATOM;
     stmt->_.create_atom.dest = dest;
     return stmt;
 }
@@ -599,7 +599,7 @@ s0_create_atom_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_atom_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_ATOM);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_ATOM);
     return stmt->_.create_atom.dest;
 }
 
@@ -615,7 +615,7 @@ s0_create_closure_new(struct s0_name *dest, struct s0_name_set *closed_over,
         s0_named_blocks_free(branches);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_TYPE_CREATE_CLOSURE;
+    stmt->type = S0_STATEMENT_KIND_CREATE_CLOSURE;
     stmt->_.create_closure.dest = dest;
     stmt->_.create_closure.closed_over = closed_over;
     stmt->_.create_closure.branches = branches;
@@ -633,21 +633,21 @@ s0_create_closure_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_closure_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_CLOSURE);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.dest;
 }
 
 struct s0_name_set *
 s0_create_closure_closed_over(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_CLOSURE);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.closed_over;
 }
 
 struct s0_named_blocks *
 s0_create_closure_branches(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_CLOSURE);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.branches;
 }
 
@@ -660,7 +660,7 @@ s0_create_literal_new(struct s0_name *dest, size_t size, const void *content)
         s0_name_free(dest);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_TYPE_CREATE_LITERAL;
+    stmt->type = S0_STATEMENT_KIND_CREATE_LITERAL;
     stmt->_.create_literal.dest = dest;
     stmt->_.create_literal.size = size;
     stmt->_.create_literal.content = malloc(size);
@@ -683,21 +683,21 @@ s0_create_literal_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_literal_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_LITERAL);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.dest;
 }
 
 const void *
 s0_create_literal_content(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_LITERAL);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.content;
 }
 
 size_t
 s0_create_literal_size(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_LITERAL);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.size;
 }
 
@@ -713,7 +713,7 @@ s0_create_method_new(struct s0_name *dest, struct s0_name *self_input,
         s0_block_free(body);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_TYPE_CREATE_METHOD;
+    stmt->type = S0_STATEMENT_KIND_CREATE_METHOD;
     stmt->_.create_method.dest = dest;
     stmt->_.create_method.self_input = self_input;
     stmt->_.create_method.body = body;
@@ -731,21 +731,21 @@ s0_create_method_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_method_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_METHOD);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.dest;
 }
 
 struct s0_name *
 s0_create_method_self_input(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_METHOD);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.self_input;
 }
 
 struct s0_block *
 s0_create_method_body(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_TYPE_CREATE_METHOD);
+    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.body;
 }
 
@@ -754,16 +754,16 @@ void
 s0_statement_free(struct s0_statement *stmt)
 {
     switch (stmt->type) {
-        case S0_STATEMENT_TYPE_CREATE_ATOM:
+        case S0_STATEMENT_KIND_CREATE_ATOM:
             s0_create_atom_free(stmt);
             break;
-        case S0_STATEMENT_TYPE_CREATE_CLOSURE:
+        case S0_STATEMENT_KIND_CREATE_CLOSURE:
             s0_create_closure_free(stmt);
             break;
-        case S0_STATEMENT_TYPE_CREATE_LITERAL:
+        case S0_STATEMENT_KIND_CREATE_LITERAL:
             s0_create_literal_free(stmt);
             break;
-        case S0_STATEMENT_TYPE_CREATE_METHOD:
+        case S0_STATEMENT_KIND_CREATE_METHOD:
             s0_create_method_free(stmt);
             break;
         default:
@@ -773,8 +773,8 @@ s0_statement_free(struct s0_statement *stmt)
     free(stmt);
 }
 
-enum s0_statement_type
-s0_statement_type(const struct s0_statement *stmt)
+enum s0_statement_kind
+s0_statement_kind(const struct s0_statement *stmt)
 {
     return stmt->type;
 }
@@ -860,7 +860,7 @@ s0_statement_list_at(const struct s0_statement_list *list, size_t index)
  */
 
 struct s0_invocation {
-    enum s0_invocation_type  type;
+    enum s0_invocation_kind  type;
     union {
         struct {
             struct s0_name  *src;
@@ -883,7 +883,7 @@ s0_invoke_closure_new(struct s0_name *src, struct s0_name *branch)
         s0_name_free(branch);
         return NULL;
     }
-    invocation->type = S0_INVOCATION_TYPE_INVOKE_CLOSURE;
+    invocation->type = S0_INVOCATION_KIND_INVOKE_CLOSURE;
     invocation->_.invoke_closure.src = src;
     invocation->_.invoke_closure.branch = branch;
     return invocation;
@@ -899,14 +899,14 @@ s0_invoke_closure_free(struct s0_invocation *invocation)
 struct s0_name *
 s0_invoke_closure_src(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_TYPE_INVOKE_CLOSURE);
+    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_CLOSURE);
     return invocation->_.invoke_closure.src;
 }
 
 struct s0_name *
 s0_invoke_closure_branch(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_TYPE_INVOKE_CLOSURE);
+    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_CLOSURE);
     return invocation->_.invoke_closure.branch;
 }
 
@@ -920,7 +920,7 @@ s0_invoke_method_new(struct s0_name *src, struct s0_name *method)
         s0_name_free(method);
         return NULL;
     }
-    invocation->type = S0_INVOCATION_TYPE_INVOKE_METHOD;
+    invocation->type = S0_INVOCATION_KIND_INVOKE_METHOD;
     invocation->_.invoke_method.src = src;
     invocation->_.invoke_method.method = method;
     return invocation;
@@ -936,14 +936,14 @@ s0_invoke_method_free(struct s0_invocation *invocation)
 struct s0_name *
 s0_invoke_method_src(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_TYPE_INVOKE_METHOD);
+    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_METHOD);
     return invocation->_.invoke_method.src;
 }
 
 struct s0_name *
 s0_invoke_method_method(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_TYPE_INVOKE_METHOD);
+    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_METHOD);
     return invocation->_.invoke_method.method;
 }
 
@@ -952,10 +952,10 @@ void
 s0_invocation_free(struct s0_invocation *invocation)
 {
     switch (invocation->type) {
-        case S0_INVOCATION_TYPE_INVOKE_CLOSURE:
+        case S0_INVOCATION_KIND_INVOKE_CLOSURE:
             s0_invoke_closure_free(invocation);
             break;
-        case S0_INVOCATION_TYPE_INVOKE_METHOD:
+        case S0_INVOCATION_KIND_INVOKE_METHOD:
             s0_invoke_method_free(invocation);
             break;
         default:
@@ -965,8 +965,8 @@ s0_invocation_free(struct s0_invocation *invocation)
     free(invocation);
 }
 
-enum s0_invocation_type
-s0_invocation_type(const struct s0_invocation *invocation)
+enum s0_invocation_kind
+s0_invocation_kind(const struct s0_invocation *invocation)
 {
     return invocation->type;
 }
@@ -977,7 +977,7 @@ s0_invocation_type(const struct s0_invocation *invocation)
  */
 
 struct s0_entity {
-    enum s0_entity_type  type;
+    enum s0_entity_kind  type;
     union {
         struct {
             struct s0_environment  *env;
@@ -1007,7 +1007,7 @@ s0_atom_new(void)
     if (unlikely(atom == NULL)) {
         return NULL;
     }
-    atom->type = S0_ENTITY_TYPE_ATOM;
+    atom->type = S0_ENTITY_KIND_ATOM;
     return atom;
 }
 
@@ -1020,8 +1020,8 @@ s0_atom_free(struct s0_entity *atom)
 bool
 s0_atom_eq(const struct s0_entity *a1, const struct s0_entity *a2)
 {
-    assert(a1->type == S0_ENTITY_TYPE_ATOM);
-    assert(a2->type == S0_ENTITY_TYPE_ATOM);
+    assert(a1->type == S0_ENTITY_KIND_ATOM);
+    assert(a2->type == S0_ENTITY_KIND_ATOM);
     return (a1 == a2);
 }
 
@@ -1035,7 +1035,7 @@ s0_closure_new(struct s0_environment *env, struct s0_named_blocks *blocks)
         s0_named_blocks_free(blocks);
         return NULL;
     }
-    closure->type = S0_ENTITY_TYPE_CLOSURE;
+    closure->type = S0_ENTITY_KIND_CLOSURE;
     closure->_.closure.env = env;
     closure->_.closure.blocks = blocks;
     return closure;
@@ -1051,14 +1051,14 @@ s0_closure_free(struct s0_entity *closure)
 struct s0_environment *
 s0_closure_environment(const struct s0_entity *closure)
 {
-    assert(closure->type == S0_ENTITY_TYPE_CLOSURE);
+    assert(closure->type == S0_ENTITY_KIND_CLOSURE);
     return closure->_.closure.env;
 }
 
 struct s0_named_blocks *
 s0_closure_named_blocks(const struct s0_entity *closure)
 {
-    assert(closure->type == S0_ENTITY_TYPE_CLOSURE);
+    assert(closure->type == S0_ENTITY_KIND_CLOSURE);
     return closure->_.closure.blocks;
 }
 
@@ -1070,7 +1070,7 @@ s0_literal_new(size_t size, const void *content)
     if (unlikely(literal == NULL)) {
         return NULL;
     }
-    literal->type = S0_ENTITY_TYPE_LITERAL;
+    literal->type = S0_ENTITY_KIND_LITERAL;
     literal->_.literal.size = size;
     literal->_.literal.content = malloc(size);
     if (unlikely(literal->_.literal.content == NULL)) {
@@ -1096,14 +1096,14 @@ s0_literal_free(struct s0_entity *literal)
 const char *
 s0_literal_content(const struct s0_entity *literal)
 {
-    assert(literal->type == S0_ENTITY_TYPE_LITERAL);
+    assert(literal->type == S0_ENTITY_KIND_LITERAL);
     return literal->_.literal.content;
 }
 
 size_t
 s0_literal_size(const struct s0_entity *literal)
 {
-    assert(literal->type == S0_ENTITY_TYPE_LITERAL);
+    assert(literal->type == S0_ENTITY_KIND_LITERAL);
     return literal->_.literal.size;
 }
 
@@ -1117,7 +1117,7 @@ s0_method_new(struct s0_name *self_name, struct s0_block *block)
         s0_block_free(block);
         return NULL;
     }
-    method->type = S0_ENTITY_TYPE_METHOD;
+    method->type = S0_ENTITY_KIND_METHOD;
     method->_.method.self_name = self_name;
     method->_.method.block = block;
     return method;
@@ -1133,14 +1133,14 @@ s0_method_free(struct s0_entity *method)
 struct s0_name *
 s0_method_self_name(const struct s0_entity *method)
 {
-    assert(method->type == S0_ENTITY_TYPE_METHOD);
+    assert(method->type == S0_ENTITY_KIND_METHOD);
     return method->_.method.self_name;
 }
 
 struct s0_block *
 s0_method_block(const struct s0_entity *method)
 {
-    assert(method->type == S0_ENTITY_TYPE_METHOD);
+    assert(method->type == S0_ENTITY_KIND_METHOD);
     return method->_.method.block;
 }
 
@@ -1154,7 +1154,7 @@ s0_object_new(void)
     if (unlikely(obj == NULL)) {
         return NULL;
     }
-    obj->type = S0_ENTITY_TYPE_OBJECT;
+    obj->type = S0_ENTITY_KIND_OBJECT;
     obj->_.obj.size = 0;
     obj->_.obj.allocated_size = DEFAULT_INITIAL_OBJECT_SIZE;
     obj->_.obj.entries =
@@ -1206,14 +1206,14 @@ s0_object_add(struct s0_entity *obj,
 size_t
 s0_object_size(const struct s0_entity *obj)
 {
-    assert(obj->type == S0_ENTITY_TYPE_OBJECT);
+    assert(obj->type == S0_ENTITY_KIND_OBJECT);
     return obj->_.obj.size;
 }
 
 struct s0_object_entry
 s0_object_at(const struct s0_entity *obj, size_t index)
 {
-    assert(obj->type == S0_ENTITY_TYPE_OBJECT);
+    assert(obj->type == S0_ENTITY_KIND_OBJECT);
     assert(index < obj->_.obj.size);
     return obj->_.obj.entries[index];
 }
@@ -1222,7 +1222,7 @@ struct s0_entity *
 s0_object_get(const struct s0_entity *obj, const struct s0_name *name)
 {
     size_t  i;
-    assert(obj->type == S0_ENTITY_TYPE_OBJECT);
+    assert(obj->type == S0_ENTITY_KIND_OBJECT);
     for (i = 0; i < obj->_.obj.size; i++) {
         if (s0_name_eq(obj->_.obj.entries[i].name, name)) {
             return obj->_.obj.entries[i].entity;
@@ -1236,19 +1236,19 @@ void
 s0_entity_free(struct s0_entity *entity)
 {
     switch (entity->type) {
-        case S0_ENTITY_TYPE_ATOM:
+        case S0_ENTITY_KIND_ATOM:
             s0_atom_free(entity);
             break;
-        case S0_ENTITY_TYPE_CLOSURE:
+        case S0_ENTITY_KIND_CLOSURE:
             s0_closure_free(entity);
             break;
-        case S0_ENTITY_TYPE_LITERAL:
+        case S0_ENTITY_KIND_LITERAL:
             s0_literal_free(entity);
             break;
-        case S0_ENTITY_TYPE_METHOD:
+        case S0_ENTITY_KIND_METHOD:
             s0_method_free(entity);
             break;
-        case S0_ENTITY_TYPE_OBJECT:
+        case S0_ENTITY_KIND_OBJECT:
             s0_object_free(entity);
             break;
         default:
@@ -1258,8 +1258,8 @@ s0_entity_free(struct s0_entity *entity)
     free(entity);
 }
 
-enum s0_entity_type
-s0_entity_type(const struct s0_entity *entity)
+enum s0_entity_kind
+s0_entity_kind(const struct s0_entity *entity)
 {
     return entity->type;
 }

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1475,6 +1475,40 @@ s0_environment_type_delete(struct s0_environment_type *type,
 }
 
 int
+s0_environment_type_extract(struct s0_environment_type *dest,
+                            struct s0_environment_type *src,
+                            const struct s0_name_set *set)
+{
+    size_t  i;
+    for (i = 0; i < set->size; i++) {
+        const struct s0_name  *name = set->names[i];
+        struct s0_entity_type  *etype;
+
+        if (unlikely(s0_environment_type_get(dest, name) != NULL)) {
+            return -1;
+        }
+
+        etype = s0_environment_type_delete(src, name);
+        if (etype == NULL) {
+            return -1;
+        } else {
+            int  rc;
+            struct s0_name  *name_copy = s0_name_new_copy(name);
+            if (unlikely(name_copy == NULL)) {
+                s0_entity_type_free(etype);
+                return ENOMEM;
+            }
+
+            rc = s0_environment_type_add(dest, name_copy, etype);
+            if (unlikely(rc != 0)) {
+                return ENOMEM;
+            }
+        }
+    }
+    return 0;
+}
+
+int
 s0_environment_type_add_external_inputs(struct s0_environment_type *type,
                                         const struct s0_name_mapping *inputs)
 {

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1456,6 +1456,24 @@ s0_environment_type_get(const struct s0_environment_type *type,
     return NULL;
 }
 
+struct s0_entity_type *
+s0_environment_type_delete(struct s0_environment_type *type,
+                           const struct s0_name *name)
+{
+    size_t  i;
+    for (i = 0; i < type->size; i++) {
+        if (s0_name_eq(type->entries[i].name, name)) {
+            struct s0_entity_type  *result = type->entries[i].type;
+            s0_name_free(type->entries[i].name);
+            memmove(&type->entries[i], &type->entries[i + 1],
+                    sizeof(type->entries[i]) * (type->size - i - 1));
+            type->size--;
+            return result;
+        }
+    }
+    return NULL;
+}
+
 int
 s0_environment_type_add_external_inputs(struct s0_environment_type *type,
                                         const struct s0_name_mapping *inputs)

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1263,3 +1263,70 @@ s0_entity_kind(const struct s0_entity *entity)
 {
     return entity->type;
 }
+
+
+/*-----------------------------------------------------------------------------
+ * S₀: Entity types
+ */
+
+struct s0_entity_type {
+    enum s0_entity_type_kind  kind;
+};
+
+struct s0_entity_type *
+s0_any_entity_type_new(void)
+{
+    struct s0_entity_type  *any = malloc(sizeof(struct s0_entity_type));
+    if (unlikely(any == NULL)) {
+        return NULL;
+    }
+    any->kind = S0_ENTITY_TYPE_KIND_ANY;
+    return any;
+}
+
+static void
+s0_any_entity_type_free(struct s0_entity_type *any)
+{
+    /* Nothing to do */
+}
+
+static bool
+s0_any_entity_type_satisfied_by(const struct s0_entity_type *any,
+                                const struct s0_entity *entity)
+{
+    return true;
+}
+
+void
+s0_entity_type_free(struct s0_entity_type *type)
+{
+    switch (type->kind) {
+        case S0_ENTITY_TYPE_KIND_ANY:
+            s0_any_entity_type_free(type);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+    free(type);
+}
+
+enum s0_entity_type_kind
+s0_entity_type_kind(const struct s0_entity_type *type)
+{
+    return type->kind;
+}
+
+bool
+s0_entity_type_satisfied_by(const struct s0_entity_type *type,
+                            const struct s0_entity *entity)
+{
+    switch (type->kind) {
+        case S0_ENTITY_TYPE_KIND_ANY:
+            return s0_any_entity_type_satisfied_by(type, entity);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+}

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -44,6 +44,12 @@ s0_name_new_str(const void *content)
     return s0_name_new(strlen(content), content);
 }
 
+struct s0_name *
+s0_name_new_copy(const struct s0_name *other)
+{
+    return s0_name_new(other->size, other->content);
+}
+
 void
 s0_name_free(struct s0_name *name)
 {

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1508,6 +1508,129 @@ s0_environment_type_extract(struct s0_environment_type *dest,
     return 0;
 }
 
+static int
+s0_environment_type_add_create_atom(struct s0_environment_type *type,
+                                    const struct s0_statement *stmt)
+{
+    struct s0_entity_type  *dest_type;
+    struct s0_name  *dest_name;
+
+    dest_type = s0_environment_type_get(type, stmt->_.create_atom.dest);
+    if (unlikely(dest_type != NULL)) {
+        return -1;
+    }
+
+    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    if (unlikely(dest_name == NULL)) {
+        return -1;
+    }
+
+    dest_type = s0_any_entity_type_new();
+    if (unlikely(dest_type == NULL)) {
+        s0_name_free(dest_name);
+        return -1;
+    }
+
+    return s0_environment_type_add(type, dest_name, dest_type);
+}
+
+static int
+s0_environment_type_add_create_closure(struct s0_environment_type *type,
+                                       const struct s0_statement *stmt)
+{
+    struct s0_entity_type  *dest_type;
+    struct s0_name  *dest_name;
+
+    dest_type = s0_environment_type_get(type, stmt->_.create_closure.dest);
+    if (unlikely(dest_type != NULL)) {
+        return -1;
+    }
+
+    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    if (unlikely(dest_name == NULL)) {
+        return -1;
+    }
+
+    dest_type = s0_any_entity_type_new();
+    if (unlikely(dest_type == NULL)) {
+        s0_name_free(dest_name);
+        return -1;
+    }
+
+    return s0_environment_type_add(type, dest_name, dest_type);
+}
+
+static int
+s0_environment_type_add_create_literal(struct s0_environment_type *type,
+                                       const struct s0_statement *stmt)
+{
+    struct s0_entity_type  *dest_type;
+    struct s0_name  *dest_name;
+
+    dest_type = s0_environment_type_get(type, stmt->_.create_literal.dest);
+    if (unlikely(dest_type != NULL)) {
+        return -1;
+    }
+
+    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    if (unlikely(dest_name == NULL)) {
+        return -1;
+    }
+
+    dest_type = s0_any_entity_type_new();
+    if (unlikely(dest_type == NULL)) {
+        s0_name_free(dest_name);
+        return -1;
+    }
+
+    return s0_environment_type_add(type, dest_name, dest_type);
+}
+
+static int
+s0_environment_type_add_create_method(struct s0_environment_type *type,
+                                      const struct s0_statement *stmt)
+{
+    struct s0_entity_type  *dest_type;
+    struct s0_name  *dest_name;
+
+    dest_type = s0_environment_type_get(type, stmt->_.create_method.dest);
+    if (unlikely(dest_type != NULL)) {
+        return -1;
+    }
+
+    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    if (unlikely(dest_name == NULL)) {
+        return -1;
+    }
+
+    dest_type = s0_any_entity_type_new();
+    if (unlikely(dest_type == NULL)) {
+        s0_name_free(dest_name);
+        return -1;
+    }
+
+    return s0_environment_type_add(type, dest_name, dest_type);
+}
+
+int
+s0_environment_type_add_statement(struct s0_environment_type *type,
+                                  const struct s0_statement *stmt)
+{
+    switch (stmt->type) {
+        case S0_STATEMENT_KIND_CREATE_ATOM:
+            return s0_environment_type_add_create_atom(type, stmt);
+        case S0_STATEMENT_KIND_CREATE_CLOSURE:
+            return s0_environment_type_add_create_closure(type, stmt);
+        case S0_STATEMENT_KIND_CREATE_LITERAL:
+            return s0_environment_type_add_create_literal(type, stmt);
+        case S0_STATEMENT_KIND_CREATE_METHOD:
+            return s0_environment_type_add_create_method(type, stmt);
+        default:
+            assert(false);
+            break;
+    }
+}
+
 int
 s0_environment_type_add_external_inputs(struct s0_environment_type *type,
                                         const struct s0_name_mapping *inputs)

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -217,6 +217,7 @@ s0_name_mapping_free(struct s0_name_mapping *mapping)
     for (i = 0; i < mapping->size; i++) {
         s0_name_free(mapping->entries[i].from);
         s0_name_free(mapping->entries[i].to);
+        s0_entity_type_free(mapping->entries[i].type);
     }
     free(mapping->entries);
     free(mapping);
@@ -224,7 +225,7 @@ s0_name_mapping_free(struct s0_name_mapping *mapping)
 
 int
 s0_name_mapping_add(struct s0_name_mapping *mapping, struct s0_name *from,
-                    struct s0_name *to)
+                    struct s0_name *to, struct s0_entity_type *type)
 {
     struct s0_name_mapping_entry  *new_entry;
 
@@ -236,6 +237,7 @@ s0_name_mapping_add(struct s0_name_mapping *mapping, struct s0_name *from,
         if (unlikely(new_entries == NULL)) {
             s0_name_free(from);
             s0_name_free(to);
+            s0_entity_type_free(type);
             return -1;
         }
         mapping->entries = new_entries;
@@ -245,6 +247,7 @@ s0_name_mapping_add(struct s0_name_mapping *mapping, struct s0_name *from,
     new_entry = &mapping->entries[mapping->size++];
     new_entry->from = from;
     new_entry->to = to;
+    new_entry->type = type;
     return 0;
 }
 
@@ -254,34 +257,34 @@ s0_name_mapping_size(const struct s0_name_mapping *mapping)
     return mapping->size;
 }
 
-struct s0_name_mapping_entry
+const struct s0_name_mapping_entry *
 s0_name_mapping_at(const struct s0_name_mapping *mapping, size_t index)
 {
     assert(index < mapping->size);
-    return mapping->entries[index];
+    return &mapping->entries[index];
 }
 
-struct s0_name *
+const struct s0_name_mapping_entry *
 s0_name_mapping_get(const struct s0_name_mapping *mapping,
                     const struct s0_name *from)
 {
     size_t  i;
     for (i = 0; i < mapping->size; i++) {
         if (s0_name_eq(mapping->entries[i].from, from)) {
-            return mapping->entries[i].to;
+            return &mapping->entries[i];
         }
     }
     return NULL;
 }
 
-struct s0_name *
+const struct s0_name_mapping_entry *
 s0_name_mapping_get_from(const struct s0_name_mapping *mapping,
                          const struct s0_name *to)
 {
     size_t  i;
     for (i = 0; i < mapping->size; i++) {
         if (s0_name_eq(mapping->entries[i].to, to)) {
-            return mapping->entries[i].from;
+            return &mapping->entries[i];
         }
     }
     return NULL;

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -6,6 +6,7 @@
 #include "swanson.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ccan/likely/likely.h"
@@ -1453,6 +1454,74 @@ s0_environment_type_get(const struct s0_environment_type *type,
         }
     }
     return NULL;
+}
+
+int
+s0_environment_type_add_external_inputs(struct s0_environment_type *type,
+                                        const struct s0_name_mapping *inputs)
+{
+    size_t  i;
+    for (i = 0; i < inputs->size; i++) {
+        const struct s0_name  *name = inputs->entries[i].from;
+        if (s0_environment_type_get(type, name) != NULL) {
+            return -1;
+        } else {
+            int  rc;
+            struct s0_name  *name_copy;
+            struct s0_entity_type  *etype_copy;
+
+            name_copy = s0_name_new_copy(name);
+            if (unlikely(name_copy == NULL)) {
+                return ENOMEM;
+            }
+
+            etype_copy = s0_entity_type_new_copy(inputs->entries[i].type);
+            if (unlikely(etype_copy == NULL)) {
+                s0_name_free(name_copy);
+                return ENOMEM;
+            }
+
+            rc = s0_environment_type_add(type, name_copy, etype_copy);
+            if (unlikely(rc != 0)) {
+                return ENOMEM;
+            }
+        }
+    }
+    return 0;
+}
+
+int
+s0_environment_type_add_internal_inputs(struct s0_environment_type *type,
+                                        const struct s0_name_mapping *inputs)
+{
+    size_t  i;
+    for (i = 0; i < inputs->size; i++) {
+        const struct s0_name  *name = inputs->entries[i].to;
+        if (s0_environment_type_get(type, name) != NULL) {
+            return -1;
+        } else {
+            int  rc;
+            struct s0_name  *name_copy;
+            struct s0_entity_type  *etype_copy;
+
+            name_copy = s0_name_new_copy(name);
+            if (unlikely(name_copy == NULL)) {
+                return ENOMEM;
+            }
+
+            etype_copy = s0_entity_type_new_copy(inputs->entries[i].type);
+            if (unlikely(etype_copy == NULL)) {
+                s0_name_free(name_copy);
+                return ENOMEM;
+            }
+
+            rc = s0_environment_type_add(type, name_copy, etype_copy);
+            if (unlikely(rc != 0)) {
+                return ENOMEM;
+            }
+        }
+    }
+    return 0;
 }
 
 bool

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1289,6 +1289,12 @@ s0_any_entity_type_new(void)
     return any;
 }
 
+static struct s0_entity_type *
+s0_any_entity_type_new_copy(const struct s0_entity_type *other)
+{
+    return s0_any_entity_type_new();
+}
+
 static void
 s0_any_entity_type_free(struct s0_entity_type *any)
 {
@@ -1300,6 +1306,19 @@ s0_any_entity_type_satisfied_by(const struct s0_entity_type *any,
                                 const struct s0_entity *entity)
 {
     return true;
+}
+
+struct s0_entity_type *
+s0_entity_type_new_copy(const struct s0_entity_type *other)
+{
+    switch (other->kind) {
+        case S0_ENTITY_TYPE_KIND_ANY:
+            return s0_any_entity_type_new_copy(other);
+            break;
+        default:
+            assert(false);
+            break;
+    }
 }
 
 void

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -294,6 +294,7 @@ struct s0_environment_entry {
 
 struct s0_environment {
     struct s0_environment_entry  *head;
+    size_t  size;
 };
 
 struct s0_environment *
@@ -304,6 +305,7 @@ s0_environment_new(void)
         return NULL;
     }
     env->head = NULL;
+    env->size = 0;
     return env;
 }
 
@@ -324,12 +326,7 @@ s0_environment_free(struct s0_environment *env)
 size_t
 s0_environment_size(const struct s0_environment *env)
 {
-    size_t  size = 0;
-    struct s0_environment_entry  *curr;
-    for (curr = env->head; curr != NULL; curr = curr->next) {
-        size++;
-    }
-    return size;
+    return env->size;
 }
 
 int
@@ -358,6 +355,7 @@ s0_environment_add(struct s0_environment *env,
     entry->entity = entity;
     entry->next = env->head;
     env->head = entry;
+    env->size++;
     return 0;
 }
 
@@ -389,6 +387,7 @@ s0_environment_delete(struct s0_environment *env, const struct s0_name *name)
             }
             s0_name_free(curr->name);
             free(curr);
+            env->size--;
             return entity;
         }
     }

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -325,6 +325,7 @@ s0_load_name_mapping(struct s0_yaml_node node)
         struct s0_yaml_node  item;
         struct s0_name  *from;
         struct s0_name  *to;
+        struct s0_entity_type  *type;
 
         item = s0_yaml_node_mapping_key_at(node, i);
         from = s0_load_name(item);
@@ -363,7 +364,16 @@ s0_load_name_mapping(struct s0_yaml_node node)
             return NULL;
         }
 
-        if (unlikely(s0_name_mapping_add(mapping, from, to))) {
+        type = s0_any_entity_type_new();
+        if (unlikely(type == NULL)) {
+            fill_memory_error(node.stream);
+            s0_name_free(from);
+            s0_name_free(to);
+            s0_name_mapping_free(mapping);
+            return NULL;
+        }
+
+        if (unlikely(s0_name_mapping_add(mapping, from, to, type))) {
             fill_memory_error(node.stream);
             s0_name_mapping_free(mapping);
             return NULL;

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -666,7 +666,8 @@ s0_load_statement(struct s0_yaml_node node)
 }
 
 static struct s0_statement_list *
-s0_load_statement_list(struct s0_yaml_node node)
+s0_load_statement_list(struct s0_yaml_node node,
+                       struct s0_environment_type *type)
 {
     struct s0_statement_list  *list;
     size_t  i;
@@ -676,6 +677,7 @@ s0_load_statement_list(struct s0_yaml_node node)
     count = s0_yaml_node_sequence_size(node);
     list = s0_statement_list_new();
     for (i = 0; i < count; i++) {
+        int  rc;
         struct s0_yaml_node  item = s0_yaml_node_sequence_at(node, i);
         struct s0_statement  *statement = s0_load_statement(item);
         if (unlikely(statement == NULL)) {
@@ -683,7 +685,18 @@ s0_load_statement_list(struct s0_yaml_node node)
             return NULL;
         }
 
-        if (unlikely(s0_statement_list_add(list, statement))) {
+        rc = s0_environment_type_add_statement(type, statement);
+        if (unlikely(rc != 0)) {
+            fill_error(node.stream, "Statement has invalid type at %zu:%zu",
+                       s0_yaml_node_get_node(node)->start_mark.line,
+                       s0_yaml_node_get_node(node)->start_mark.column);
+            s0_statement_free(statement);
+            s0_statement_list_free(list);
+            return NULL;
+        }
+
+        rc = s0_statement_list_add(list, statement);
+        if (unlikely(rc != 0)) {
             s0_statement_list_free(list);
             return NULL;
         }
@@ -797,8 +810,10 @@ s0_load_invocation(struct s0_yaml_node node)
 static struct s0_block *
 s0_load_block(struct s0_yaml_node node)
 {
+    int  rc;
     struct s0_yaml_node  item;
     struct s0_name_mapping  *inputs;
+    struct s0_environment_type  *type;
     struct s0_statement_list  *statements;
     struct s0_invocation  *invocation;
 
@@ -819,6 +834,23 @@ s0_load_block(struct s0_yaml_node node)
         return NULL;
     }
 
+    type = s0_environment_type_new();
+    if (unlikely(type == NULL)) {
+        fill_memory_error(node.stream);
+        s0_name_mapping_free(inputs);
+        return NULL;
+    }
+
+    rc = s0_environment_type_add_internal_inputs(type, inputs);
+    if (unlikely(rc != 0)) {
+        fill_error(node.stream, "Block has invalid inputs type at %zu:%zu",
+                   s0_yaml_node_get_node(node)->start_mark.line,
+                   s0_yaml_node_get_node(node)->start_mark.column);
+        s0_name_mapping_free(inputs);
+        s0_environment_type_free(type);
+        return NULL;
+    }
+
     /* statements */
 
     item = s0_yaml_node_mapping_get(node, "statements");
@@ -827,12 +859,14 @@ s0_load_block(struct s0_yaml_node node)
                    s0_yaml_node_get_node(node)->start_mark.line,
                    s0_yaml_node_get_node(node)->start_mark.column);
         s0_name_mapping_free(inputs);
+        s0_environment_type_free(type);
         return NULL;
     }
 
-    statements = s0_load_statement_list(item);
+    statements = s0_load_statement_list(item, type);
     if (unlikely(statements == NULL)) {
         s0_name_mapping_free(inputs);
+        s0_environment_type_free(type);
         return NULL;
     }
 
@@ -845,6 +879,7 @@ s0_load_block(struct s0_yaml_node node)
                    s0_yaml_node_get_node(node)->start_mark.column);
         s0_name_mapping_free(inputs);
         s0_statement_list_free(statements);
+        s0_environment_type_free(type);
         return NULL;
     }
 
@@ -852,9 +887,11 @@ s0_load_block(struct s0_yaml_node node)
     if (unlikely(invocation == NULL)) {
         s0_name_mapping_free(inputs);
         s0_statement_list_free(statements);
+        s0_environment_type_free(type);
         return NULL;
     }
 
+    s0_environment_type_free(type);
     return s0_block_new(inputs, statements, invocation);
 }
 

--- a/c/tests/test-cases.h
+++ b/c/tests/test-cases.h
@@ -198,6 +198,16 @@ exit_status(void)
 
 #define check0(call)  check0_with_msg(call, "Error occurred")
 
+#define check_nonnull_with_msg(call, msg) \
+    do { \
+        if (unlikely((call) == NULL)) { \
+            fail_at(msg, __FILE__, __LINE__); \
+            return; \
+        } \
+    } while (0)
+
+#define check_nonnull(call)  check_nonnull_with_msg(call, "Error occurred")
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -58,6 +58,18 @@ TEST_CASE("can create name with embedded NUL") {
     s0_name_free(name);
 }
 
+TEST_CASE("can create copy of name") {
+    struct s0_name  *name1;
+    struct s0_name  *name2;
+    check_alloc(name1, s0_name_new(6, "hello\x00"));
+    check_alloc(name2, s0_name_new_copy(name1));
+    check(s0_name_size(name2) == 6);
+    check(memcmp(s0_name_content(name2), "hello\x00", 6) == 0);
+    check(s0_name_eq(name1, name2));
+    s0_name_free(name1);
+    s0_name_free(name2);
+}
+
 TEST_CASE("can compare names") {
     struct s0_name  *n1;
     struct s0_name  *n2;

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -397,7 +397,7 @@ TEST_CASE("can create `create-atom` statement") {
 
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(stmt, s0_create_atom_new(dest));
-    check(s0_statement_type(stmt) == S0_STATEMENT_TYPE_CREATE_ATOM);
+    check(s0_statement_kind(stmt) == S0_STATEMENT_KIND_CREATE_ATOM);
 
     check_alloc(dest, s0_name_new_str("a"));
     check(s0_name_eq(s0_create_atom_dest(stmt), dest));
@@ -416,7 +416,7 @@ TEST_CASE("can create `create-closure` statement") {
     check_alloc(closed_over, s0_name_set_new());
     check_alloc(branches, s0_named_blocks_new());
     check_alloc(stmt, s0_create_closure_new(dest, closed_over, branches));
-    check(s0_statement_type(stmt) == S0_STATEMENT_TYPE_CREATE_CLOSURE);
+    check(s0_statement_kind(stmt) == S0_STATEMENT_KIND_CREATE_CLOSURE);
 
     check_alloc(dest, s0_name_new_str("a"));
     check(s0_name_eq(s0_create_closure_dest(stmt), dest));
@@ -434,7 +434,7 @@ TEST_CASE("can create `create-literal` statement") {
 
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(stmt, s0_create_literal_new(dest, 5, "hello"));
-    check(s0_statement_type(stmt) == S0_STATEMENT_TYPE_CREATE_LITERAL);
+    check(s0_statement_kind(stmt) == S0_STATEMENT_KIND_CREATE_LITERAL);
 
     check_alloc(dest, s0_name_new_str("a"));
     check(s0_name_eq(s0_create_literal_dest(stmt), dest));
@@ -456,7 +456,7 @@ TEST_CASE("can create `create-method` statement") {
     check_alloc(self_input, s0_name_new_str("self"));
     check_alloc(body, create_empty_block());
     check_alloc(stmt, s0_create_method_new(dest, self_input, body));
-    check(s0_statement_type(stmt) == S0_STATEMENT_TYPE_CREATE_METHOD);
+    check(s0_statement_kind(stmt) == S0_STATEMENT_KIND_CREATE_METHOD);
 
     check_alloc(dest, s0_name_new_str("a"));
     check(s0_name_eq(s0_create_method_dest(stmt), dest));
@@ -553,7 +553,7 @@ TEST_CASE("can create `invoke-closure` invocation") {
     check_alloc(src, s0_name_new_str("a"));
     check_alloc(branch, s0_name_new_str("body"));
     check_alloc(invocation, s0_invoke_closure_new(src, branch));
-    check(s0_invocation_type(invocation) == S0_INVOCATION_TYPE_INVOKE_CLOSURE);
+    check(s0_invocation_kind(invocation) == S0_INVOCATION_KIND_INVOKE_CLOSURE);
 
     check_alloc(src, s0_name_new_str("a"));
     check(s0_name_eq(s0_invoke_closure_src(invocation), src));
@@ -574,7 +574,7 @@ TEST_CASE("can create `invoke-method` invocation") {
     check_alloc(src, s0_name_new_str("a"));
     check_alloc(method, s0_name_new_str("run"));
     check_alloc(invocation, s0_invoke_method_new(src, method));
-    check(s0_invocation_type(invocation) == S0_INVOCATION_TYPE_INVOKE_METHOD);
+    check(s0_invocation_kind(invocation) == S0_INVOCATION_KIND_INVOKE_METHOD);
 
     check_alloc(src, s0_name_new_str("a"));
     check(s0_name_eq(s0_invoke_method_src(invocation), src));
@@ -621,7 +621,7 @@ TEST_CASE_GROUP("S₀ atoms");
 TEST_CASE("can create atom") {
     struct s0_entity  *atom;
     check_alloc(atom, s0_atom_new());
-    check(s0_entity_type(atom) == S0_ENTITY_TYPE_ATOM);
+    check(s0_entity_kind(atom) == S0_ENTITY_KIND_ATOM);
     s0_entity_free(atom);
 }
 
@@ -668,7 +668,7 @@ TEST_CASE("can create closure") {
     check_alloc(env, s0_environment_new());
     check_alloc(blocks, s0_named_blocks_new());
     check_alloc(closure, s0_closure_new(env, blocks));
-    check(s0_entity_type(closure) == S0_ENTITY_TYPE_CLOSURE);
+    check(s0_entity_kind(closure) == S0_ENTITY_KIND_CLOSURE);
     check(s0_closure_environment(closure) == env);
     check(s0_closure_named_blocks(closure) == blocks);
     s0_entity_free(closure);
@@ -683,7 +683,7 @@ TEST_CASE_GROUP("S₀ literals");
 TEST_CASE("can create literal from C string") {
     struct s0_entity  *literal;
     check_alloc(literal, s0_literal_new_str("hello"));
-    check(s0_entity_type(literal) == S0_ENTITY_TYPE_LITERAL);
+    check(s0_entity_kind(literal) == S0_ENTITY_KIND_LITERAL);
     check(s0_literal_size(literal) == 5);
     check(memcmp(s0_literal_content(literal), "hello", 5) == 0);
     s0_entity_free(literal);
@@ -692,7 +692,7 @@ TEST_CASE("can create literal from C string") {
 TEST_CASE("can create literal with explicit length") {
     struct s0_entity  *literal;
     check_alloc(literal, s0_literal_new(5, "hello"));
-    check(s0_entity_type(literal) == S0_ENTITY_TYPE_LITERAL);
+    check(s0_entity_kind(literal) == S0_ENTITY_KIND_LITERAL);
     check(s0_literal_size(literal) == 5);
     check(memcmp(s0_literal_content(literal), "hello", 5) == 0);
     s0_entity_free(literal);
@@ -701,7 +701,7 @@ TEST_CASE("can create literal with explicit length") {
 TEST_CASE("can create literal with embedded NUL") {
     struct s0_entity  *literal;
     check_alloc(literal, s0_literal_new(6, "hello\x00"));
-    check(s0_entity_type(literal) == S0_ENTITY_TYPE_LITERAL);
+    check(s0_entity_kind(literal) == S0_ENTITY_KIND_LITERAL);
     check(s0_literal_size(literal) == 6);
     check(memcmp(s0_literal_content(literal), "hello\x00", 6) == 0);
     s0_entity_free(literal);
@@ -720,7 +720,7 @@ TEST_CASE("can create method") {
     check_alloc(self_name, s0_name_new_str("self"));
     check_alloc(block, create_empty_block());
     check_alloc(method, s0_method_new(self_name, block));
-    check(s0_entity_type(method) == S0_ENTITY_TYPE_METHOD);
+    check(s0_entity_kind(method) == S0_ENTITY_KIND_METHOD);
     check_alloc(self_name, s0_name_new_str("self"));
     check(s0_name_eq(s0_method_self_name(method), self_name));
     s0_name_free(self_name);

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1269,6 +1269,150 @@ TEST_CASE("env(a,b) : {a: any, b: any}") {
     s0_environment_free(env);
 }
 
+TEST_CASE("can create external environment type from input mappings") {
+    struct s0_name_mapping  *mapping;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+
+    /* Create the mapping */
+    check_alloc(mapping, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+    check_alloc(from, s0_name_new_str("c"));
+    check_alloc(to, s0_name_new_str("d"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+
+    /* Create an environment type from the mapping */
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_add_external_inputs(type, mapping));
+
+    /* Result should be {a: any, c: any} */
+    check(s0_environment_type_size(type) == 2);
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    check_alloc(name, s0_name_new_str("c"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+
+    s0_environment_type_free(type);
+    s0_name_mapping_free(mapping);
+}
+
+TEST_CASE("cannot overwrite external environment type from input mappings") {
+    struct s0_name_mapping  *mapping;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+
+    /* Create the mapping */
+    check_alloc(mapping, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+    check_alloc(from, s0_name_new_str("c"));
+    check_alloc(to, s0_name_new_str("d"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+
+    /* Create an environment type with entries that overlap what we'd add from
+     * the mapping. */
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("c"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check(s0_environment_type_add_external_inputs(type, mapping) == -1);
+
+    s0_environment_type_free(type);
+    s0_name_mapping_free(mapping);
+}
+
+TEST_CASE("can create internal environment type from input mappings") {
+    struct s0_name_mapping  *mapping;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+
+    /* Create the mapping */
+    check_alloc(mapping, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+    check_alloc(from, s0_name_new_str("c"));
+    check_alloc(to, s0_name_new_str("d"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+
+    /* Create an environment type from the mapping */
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_add_internal_inputs(type, mapping));
+
+    /* Result should be {b: any, d: any} */
+    check(s0_environment_type_size(type) == 2);
+    check_alloc(name, s0_name_new_str("b"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    check_alloc(name, s0_name_new_str("d"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+
+    s0_environment_type_free(type);
+    s0_name_mapping_free(mapping);
+}
+
+TEST_CASE("cannot overwrite internal environment type from input mappings") {
+    struct s0_name_mapping  *mapping;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+
+    /* Create the mapping */
+    check_alloc(mapping, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+    check_alloc(from, s0_name_new_str("c"));
+    check_alloc(to, s0_name_new_str("d"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, etype));
+
+    /* Create an environment type with entries that overlap what we'd add from
+     * the mapping. */
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("d"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check(s0_environment_type_add_internal_inputs(type, mapping) == -1);
+
+    s0_environment_type_free(type);
+    s0_name_mapping_free(mapping);
+}
+
 /*-----------------------------------------------------------------------------
  * Harness
  */

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1194,6 +1194,64 @@ TEST_CASE("can iterate through names in type") {
     s0_environment_type_free(type);
 }
 
+TEST_CASE("can delete entries from environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_delete(type, name) == etype);
+    s0_name_free(name);
+    s0_entity_type_free(etype);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("cannot get deleted entries from environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_delete(type, name) == etype);
+    s0_name_free(name);
+    s0_entity_type_free(etype);
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_get(type, name) == NULL);
+    s0_name_free(name);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("cannot iterate deleted entries from environment type") {
+    struct s0_environment_type  *type;
+    struct s0_environment_type_entry  entry;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype1;
+    struct s0_entity_type  *etype2;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype1, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype1));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype2, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype2));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_delete(type, name) == etype1);
+    s0_name_free(name);
+    s0_entity_type_free(etype1);
+    entry = s0_environment_type_at(type, 0);
+    check_alloc(name, s0_name_new_str("b"));
+    check(s0_name_eq(entry.name, name));
+    check(entry.type == etype2);
+    s0_name_free(name);
+    s0_environment_type_free(type);
+}
+
 TEST_CASE("env() : {}") {
     struct s0_environment_type  *type;
     struct s0_environment  *env;

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -218,27 +218,32 @@ TEST_CASE("can add names to mapping") {
     struct s0_name_mapping  *mapping;
     struct s0_name  *from;
     struct s0_name  *to;
+    struct s0_entity_type  *type;
     check_alloc(mapping, s0_name_mapping_new());
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
     s0_name_mapping_free(mapping);
 }
 
 TEST_CASE("non-empty name mapping has accurate size") {
     struct s0_name_mapping  *mapping;
     struct s0_name  *from;
+    struct s0_entity_type  *type;
     struct s0_name  *to;
     check_alloc(mapping, s0_name_mapping_new());
 
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
     check(s0_name_mapping_size(mapping) == 1);
 
     check_alloc(from, s0_name_new_str("c"));
     check_alloc(to, s0_name_new_str("d"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
     check(s0_name_mapping_size(mapping) == 2);
 
     s0_name_mapping_free(mapping);
@@ -248,23 +253,31 @@ TEST_CASE("can check which names belong to mapping") {
     struct s0_name_mapping  *mapping;
     struct s0_name  *from;
     struct s0_name  *to;
+    struct s0_entity_type  *type;
+    const struct s0_name_mapping_entry  *entry;
     check_alloc(mapping, s0_name_mapping_new());
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
     check_alloc(from, s0_name_new_str("c"));
     check_alloc(to, s0_name_new_str("d"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
 
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check(s0_name_eq(s0_name_mapping_get(mapping, from), to));
+    check_nonnull(entry = s0_name_mapping_get(mapping, from));
+    check(s0_name_eq(entry->to, to));
+    check(s0_entity_type_kind(entry->type) == S0_ENTITY_TYPE_KIND_ANY);
     s0_name_free(from);
     s0_name_free(to);
 
     check_alloc(from, s0_name_new_str("c"));
     check_alloc(to, s0_name_new_str("d"));
-    check(s0_name_eq(s0_name_mapping_get(mapping, from), to));
+    check_nonnull(entry = s0_name_mapping_get(mapping, from));
+    check(s0_name_eq(entry->to, to));
+    check(s0_entity_type_kind(entry->type) == S0_ENTITY_TYPE_KIND_ANY);
     s0_name_free(from);
     s0_name_free(to);
 
@@ -277,33 +290,38 @@ TEST_CASE("can check which names belong to mapping") {
 
 TEST_CASE("can iterate through names in mapping") {
     struct s0_name_mapping  *mapping;
-    struct s0_name_mapping_entry  entry;
+    const struct s0_name_mapping_entry  *entry;
     struct s0_name  *from;
     struct s0_name  *to;
+    struct s0_entity_type  *type;
     check_alloc(mapping, s0_name_mapping_new());
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
     check_alloc(from, s0_name_new_str("c"));
     check_alloc(to, s0_name_new_str("d"));
-    check0(s0_name_mapping_add(mapping, from, to));
+    check_alloc(type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(mapping, from, to, type));
 
     /* This test assumes that the names are returned in the same order that they
      * were added to the mapping. */
 
-    entry = s0_name_mapping_at(mapping, 0);
+    check_nonnull(entry = s0_name_mapping_at(mapping, 0));
     check_alloc(from, s0_name_new_str("a"));
     check_alloc(to, s0_name_new_str("b"));
-    check(s0_name_eq(entry.from, from));
-    check(s0_name_eq(entry.to, to));
+    check(s0_name_eq(entry->from, from));
+    check(s0_name_eq(entry->to, to));
+    check(s0_entity_type_kind(entry->type) == S0_ENTITY_TYPE_KIND_ANY);
     s0_name_free(from);
     s0_name_free(to);
 
-    entry = s0_name_mapping_at(mapping, 1);
+    check_nonnull(entry = s0_name_mapping_at(mapping, 1));
     check_alloc(from, s0_name_new_str("c"));
     check_alloc(to, s0_name_new_str("d"));
-    check(s0_name_eq(entry.from, from));
-    check(s0_name_eq(entry.to, to));
+    check(s0_name_eq(entry->from, from));
+    check(s0_name_eq(entry->to, to));
+    check(s0_entity_type_kind(entry->type) == S0_ENTITY_TYPE_KIND_ANY);
     s0_name_free(from);
     s0_name_free(to);
 

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -972,6 +972,70 @@ TEST_CASE("can delete entries from environment") {
 }
 
 /*-----------------------------------------------------------------------------
+ * S₀: Entity types: Any
+ */
+
+TEST_CASE_GROUP("S₀ entity types: any");
+
+TEST_CASE("atom : any") {
+    struct s0_entity_type  *any;
+    struct s0_entity  *entity;
+    check_alloc(any, s0_any_entity_type_new());
+    check_alloc(entity, s0_atom_new());
+    check(s0_entity_type_satisfied_by(any, entity));
+    s0_entity_free(entity);
+    s0_entity_type_free(any);
+}
+
+TEST_CASE("closure : any") {
+    struct s0_entity_type  *any;
+    struct s0_environment  *env;
+    struct s0_named_blocks  *blocks;
+    struct s0_entity  *entity;
+    check_alloc(any, s0_any_entity_type_new());
+    check_alloc(env, s0_environment_new());
+    check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(entity, s0_closure_new(env, blocks));
+    check(s0_entity_type_satisfied_by(any, entity));
+    s0_entity_free(entity);
+    s0_entity_type_free(any);
+}
+
+TEST_CASE("literal : any") {
+    struct s0_entity_type  *any;
+    struct s0_entity  *entity;
+    check_alloc(any, s0_any_entity_type_new());
+    check_alloc(entity, s0_literal_new_str("hello"));
+    check(s0_entity_type_satisfied_by(any, entity));
+    s0_entity_free(entity);
+    s0_entity_type_free(any);
+}
+
+TEST_CASE("method : any") {
+    struct s0_entity_type  *any;
+    struct s0_name  *self_name;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    check_alloc(any, s0_any_entity_type_new());
+    check_alloc(self_name, s0_name_new_str("self"));
+    check_alloc(block, create_empty_block());
+    check_alloc(entity, s0_method_new(self_name, block));
+    check(s0_entity_type_satisfied_by(any, entity));
+    s0_entity_free(entity);
+    s0_entity_type_free(any);
+}
+
+TEST_CASE("object : any") {
+    struct s0_entity_type  *any;
+    struct s0_entity  *entity;
+    check_alloc(any, s0_any_entity_type_new());
+    check_alloc(entity, s0_object_new());
+    check(s0_entity_type_satisfied_by(any, entity));
+    s0_entity_free(entity);
+    s0_entity_type_free(any);
+}
+
+/*-----------------------------------------------------------------------------
  * Harness
  */
 

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1402,6 +1402,86 @@ TEST_CASE("env(a,b) : {a: any, b: any}") {
     s0_environment_free(env);
 }
 
+TEST_CASE("can add `create-atom` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *dest;
+    struct s0_statement  *stmt;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(dest, s0_name_new_str("a"));
+    check_alloc(stmt, s0_create_atom_new(dest));
+    check0(s0_environment_type_add_statement(type, stmt));
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    s0_statement_free(stmt);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("can add `create-closure` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *dest;
+    struct s0_name_set  *closed_over;
+    struct s0_named_blocks  *branches;
+    struct s0_statement  *stmt;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(dest, s0_name_new_str("a"));
+    check_alloc(closed_over, s0_name_set_new());
+    check_alloc(branches, s0_named_blocks_new());
+    check_alloc(stmt, s0_create_closure_new(dest, closed_over, branches));
+    check0(s0_environment_type_add_statement(type, stmt));
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    s0_statement_free(stmt);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("can add `create-literal` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *dest;
+    struct s0_statement  *stmt;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(dest, s0_name_new_str("a"));
+    check_alloc(stmt, s0_create_literal_new(dest, 5, "hello"));
+    check0(s0_environment_type_add_statement(type, stmt));
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    s0_statement_free(stmt);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("can add `create-method` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *dest;
+    struct s0_name  *self_input;
+    struct s0_block  *body;
+    struct s0_statement  *stmt;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(dest, s0_name_new_str("a"));
+    check_alloc(self_input, s0_name_new_str("self"));
+    check_alloc(body, create_empty_block());
+    check_alloc(stmt, s0_create_method_new(dest, self_input, body));
+    check0(s0_environment_type_add_statement(type, stmt));
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+    s0_statement_free(stmt);
+    s0_environment_type_free(type);
+}
+
 TEST_CASE("can create external environment type from input mappings") {
     struct s0_name_mapping  *mapping;
     struct s0_name  *from;

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -989,6 +989,16 @@ TEST_CASE("can delete entries from environment") {
 
 TEST_CASE_GROUP("S₀ entity types: any");
 
+TEST_CASE("can copy `any` type") {
+    struct s0_entity_type  *any1;
+    struct s0_entity_type  *any2;
+    check_alloc(any1, s0_any_entity_type_new());
+    check_alloc(any2, s0_entity_type_new_copy(any1));
+    check(s0_entity_type_kind(any1) == s0_entity_type_kind(any2));
+    s0_entity_type_free(any1);
+    s0_entity_type_free(any2);
+}
+
 TEST_CASE("atom : any") {
     struct s0_entity_type  *any;
     struct s0_entity  *entity;

--- a/tests/s0/parsing/create-atom.yaml
+++ b/tests/s0/parsing/create-atom.yaml
@@ -25,35 +25,33 @@ module:
     src: exit
     branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-atom cannot overwrite an input
-# module:
-#   inputs:
-#     x: x
-#   statements:
-#     - !s0!create-atom
-#       dest: x
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-atom cannot overwrite an input
+module:
+  inputs:
+    x: x
+  statements:
+    - !s0!create-atom
+      dest: x
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-atom cannot overwrite an existing environment entry
-# module:
-#   inputs: {}
-#   statements:
-#     - !s0!create-atom
-#       dest: x
-#     - !s0!create-atom
-#       dest: x
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-atom cannot overwrite an existing environment entry
+module:
+  inputs: {}
+  statements:
+    - !s0!create-atom
+      dest: x
+    - !s0!create-atom
+      dest: x
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -96,65 +96,63 @@ module:
     src: exit
     branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-closure cannot overwrite an input
-# module:
-#   inputs:
-#     x: x
-#   statements:
-#     - !s0!create-closure
-#       dest: x
-#       closed-over: []
-#       branches:
-#         body:
-#           inputs: {}
-#           statements: []
-#           invocation:
-#             !s0!invoke-closure
-#             src: exit
-#             branch: call
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-closure cannot overwrite an input
+module:
+  inputs:
+    x: x
+  statements:
+    - !s0!create-closure
+      dest: x
+      closed-over: []
+      branches:
+        body:
+          inputs: {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: exit
+            branch: call
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-closure cannot overwrite an existing environment entry
-# module:
-#   inputs: {}
-#   statements:
-#     - !s0!create-closure
-#       dest: x
-#       closed-over: []
-#       branches:
-#         body:
-#           inputs: {}
-#           statements: []
-#           invocation:
-#             !s0!invoke-closure
-#             src: exit
-#             branch: call
-#     - !s0!create-closure
-#       dest: x
-#       closed-over: []
-#       branches:
-#         body:
-#           inputs: {}
-#           statements: []
-#           invocation:
-#             !s0!invoke-closure
-#             src: exit
-#             branch: call
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-closure cannot overwrite an existing environment entry
+module:
+  inputs: {}
+  statements:
+    - !s0!create-closure
+      dest: x
+      closed-over: []
+      branches:
+        body:
+          inputs: {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: exit
+            branch: call
+    - !s0!create-closure
+      dest: x
+      closed-over: []
+      branches:
+        body:
+          inputs: {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: exit
+            branch: call
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---

--- a/tests/s0/parsing/create-literal.yaml
+++ b/tests/s0/parsing/create-literal.yaml
@@ -133,38 +133,36 @@ module:
     src: exit
     branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-literal cannot overwrite an input
-# module:
-#   inputs:
-#     x: x
-#   statements:
-#     - !s0!create-literal
-#       dest: x
-#       content: stuff
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-literal cannot overwrite an input
+module:
+  inputs:
+    x: x
+  statements:
+    - !s0!create-literal
+      dest: x
+      content: stuff
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-literal cannot overwrite an existing environment entry
-# module:
-#   inputs: {}
-#   statements:
-#     - !s0!create-literal
-#       dest: x
-#       content: stuff
-#     - !s0!create-literal
-#       dest: x
-#       content: more stuff
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-literal cannot overwrite an existing environment entry
+module:
+  inputs: {}
+  statements:
+    - !s0!create-literal
+      dest: x
+      content: stuff
+    - !s0!create-literal
+      dest: x
+      content: more stuff
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -77,59 +77,57 @@ module:
     src: exit
     branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-method cannot overwrite an input
-# module:
-#   inputs:
-#     x: x
-#   statements:
-#     - !s0!create-method
-#       dest: x
-#       self-input: self
-#       body:
-#         inputs: {}
-#         statements: []
-#         invocation:
-#           !s0!invoke-closure
-#           src: exit
-#           branch: call
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-method cannot overwrite an input
+module:
+  inputs:
+    x: x
+  statements:
+    - !s0!create-method
+      dest: x
+      self-input: self
+      body:
+        inputs: {}
+        statements: []
+        invocation:
+          !s0!invoke-closure
+          src: exit
+          branch: call
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
 
-# TODO - need to check environment contents
-# %TAG !s0! tag:swanson-lang.org,2016:
-# ---
-# !s0!invalid-parse
-# name: create-method cannot overwrite an existing environment entry
-# module:
-#   inputs: {}
-#   statements:
-#     - !s0!create-method
-#       dest: x
-#       self-input: self
-#       body:
-#         inputs: {}
-#         statements: []
-#         invocation:
-#           !s0!invoke-closure
-#           src: exit
-#           branch: call
-#     - !s0!create-method
-#       dest: x
-#       self-input: self
-#       body:
-#         inputs: {}
-#         statements: []
-#         invocation:
-#           !s0!invoke-closure
-#           src: exit
-#           branch: call
-#   invocation:
-#     !s0!invoke-closure
-#     src: exit
-#     branch: call
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: create-method cannot overwrite an existing environment entry
+module:
+  inputs: {}
+  statements:
+    - !s0!create-method
+      dest: x
+      self-input: self
+      body:
+        inputs: {}
+        statements: []
+        invocation:
+          !s0!invoke-closure
+          src: exit
+          branch: call
+    - !s0!create-method
+      dest: x
+      self-input: self
+      body:
+        inputs: {}
+        statements: []
+        invocation:
+          !s0!invoke-closure
+          src: exit
+          branch: call
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call


### PR DESCRIPTION
Each S₀ statement creates a new entry in the environment. It's an error for the statement to overwrite an existing entry. We can verify this at runtime, but ideally we should be able to figure all of this out at parse time, since we can see what entries a block starts with, and we can see what entry each previous statement created.