### PR TITLE
Verify environment contents when parsing `invoke-closure`

### DIFF
--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -461,9 +461,11 @@ s0_object_get(const struct s0_entity *, const struct s0_name *name);
  */
 
 struct s0_entity_type;
+struct s0_environment_type_mapping;
 
 enum s0_entity_type_kind {
-    S0_ENTITY_TYPE_KIND_ANY
+    S0_ENTITY_TYPE_KIND_ANY,
+    S0_ENTITY_TYPE_KIND_CLOSURE
 };
 
 struct s0_entity_type *
@@ -489,6 +491,23 @@ s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
 
 struct s0_entity_type *
 s0_any_entity_type_new(void);
+
+
+/* Takes ownership of branches */
+struct s0_entity_type *
+s0_closure_entity_type_new(struct s0_environment_type_mapping *branches);
+
+/* Entity MUST be a closure */
+struct s0_entity_type *
+s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks);
+
+/* Entity MUST be a closure */
+struct s0_entity_type *
+s0_closure_entity_type_new_from_closure(struct s0_entity *entity);
+
+/* Retains ownership of result.  Type MUST be a closure type. */
+const struct s0_environment_type_mapping *
+s0_closure_entity_type_mapping(const struct s0_entity_type *);
 
 
 /*-----------------------------------------------------------------------------
@@ -611,8 +630,6 @@ s0_environment_type_satisfied_by_type(
 /*-----------------------------------------------------------------------------
  * S₀: Environment type mappings
  */
-
-struct s0_environment_type_mapping;
 
 struct s0_environment_type_mapping_entry {
     struct s0_name  *name;

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -548,6 +548,15 @@ int
 s0_environment_type_add_statement(struct s0_environment_type *,
                                   const struct s0_statement *stmt);
 
+/* Ensures that an environment type satisfies the prerequisites of `invocation`,
+ * and then updates the environment type based on what `invocation` would do.
+ *
+ * Returns 0 if the prereqs were satisfied and the type was updated
+ * successfully; returns -1 otherwise. */
+int
+s0_environment_type_add_invocation(struct s0_environment_type *,
+                                   const struct s0_invocation *invocation);
+
 /* Adds an entry to the environment type for each entry in a name mapping, using
  * the mapping entry's `from` name and `type`.  This type describes the
  * environment that the caller must provide when invoking a block.

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -588,6 +588,46 @@ s0_environment_type_satisfied_by(const struct s0_environment_type *,
 
 
 /*-----------------------------------------------------------------------------
+ * S₀: Environment type mappings
+ */
+
+struct s0_environment_type_mapping;
+
+struct s0_environment_type_mapping_entry {
+    struct s0_name  *name;
+    struct s0_environment_type  *type;
+};
+
+struct s0_environment_type_mapping *
+s0_environment_type_mapping_new(void);
+
+void
+s0_environment_type_mapping_free(struct s0_environment_type_mapping *);
+
+/* Takes ownership of name and type.  name MUST not already be present in
+ * mapping.  Returns 0 if type was added; -1 if we couldn't allocate space for
+ * the new entry. */
+int
+s0_environment_type_mapping_add(struct s0_environment_type_mapping *,
+                                struct s0_name *name,
+                                struct s0_environment_type *type);
+
+size_t
+s0_environment_type_mapping_size(const struct s0_environment_type_mapping *);
+
+/* Returns entries in order that they were added to mapping.  index MUST be <
+ * size of object. */
+const struct s0_environment_type_mapping_entry *
+s0_environment_type_mapping_at(const struct s0_environment_type_mapping *,
+                               size_t index);
+
+/* Returns NULL if name is not in mapping. */
+struct s0_environment_type *
+s0_environment_type_mapping_get(const struct s0_environment_type_mapping *,
+                                const struct s0_name *name);
+
+
+/*-----------------------------------------------------------------------------
  * S₀: YAML
  */
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -498,6 +498,9 @@ struct s0_environment_type_entry {
 struct s0_environment_type *
 s0_environment_type_new(void);
 
+struct s0_environment_type *
+s0_environment_type_new_copy(const struct s0_environment_type *other);
+
 void
 s0_environment_type_free(struct s0_environment_type *);
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -488,6 +488,11 @@ bool
 s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
                                  const struct s0_entity_type *have);
 
+/* Two types are equivalent if they both satisfy each other. */
+bool
+s0_entity_type_equiv(const struct s0_entity_type *,
+                     const struct s0_entity_type *);
+
 
 struct s0_entity_type *
 s0_any_entity_type_new(void);
@@ -625,6 +630,11 @@ bool
 s0_environment_type_satisfied_by_type(
         const struct s0_environment_type *requires,
         const struct s0_environment_type *have);
+
+/* Two types are equivalent if they both satisfy each other. */
+bool
+s0_environment_type_equiv(const struct s0_environment_type *,
+                          const struct s0_environment_type *);
 
 
 /*-----------------------------------------------------------------------------

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -685,6 +685,8 @@ s0_environment_type_mapping_get(const struct s0_environment_type_mapping *,
 
 
 #define SWANSON_TAG_PREFIX  "tag:swanson-lang.org,2016:"
+#define S0_ANY_TAG             SWANSON_TAG_PREFIX "any"
+#define S0_CLOSURE_TAG         SWANSON_TAG_PREFIX "closure"
 #define S0_CREATE_ATOM_TAG     SWANSON_TAG_PREFIX "create-atom"
 #define S0_CREATE_CLOSURE_TAG  SWANSON_TAG_PREFIX "create-closure"
 #define S0_CREATE_LITERAL_TAG  SWANSON_TAG_PREFIX "create-literal"
@@ -760,6 +762,10 @@ s0_yaml_stream_new_from_file(FILE *fp, const char *filename,
 struct s0_yaml_stream *
 s0_yaml_stream_new_from_filename(const char *filename);
 
+/* You must ensure `str` outlives the stream. */
+struct s0_yaml_stream *
+s0_yaml_stream_new_from_string(const char *str);
+
 void
 s0_yaml_stream_free(struct s0_yaml_stream *);
 
@@ -783,6 +789,20 @@ s0_yaml_stream_parse_document(struct s0_yaml_stream *);
  * are responsible for freeing it. */
 struct s0_entity *
 s0_yaml_document_parse_module(struct s0_yaml_node node);
+
+/* Loads an S₀ entity type from a YAML node.  If the YAML node doesn't conform
+ * to the S₀ YAML entity type schema, then we return NULL, and fill in an error
+ * on the stream that the node came from.  You take ownership of the return
+ * value and are responsible for freeing it. */
+struct s0_entity_type *
+s0_yaml_document_parse_entity_type(struct s0_yaml_node node);
+
+/* Loads an S₀ environment type from a YAML node.  If the YAML node doesn't
+ * conform to the S₀ YAML environment type schema, then we return NULL, and fill
+ * in an error on the stream that the node came from.  You take ownership of the
+ * return value and are responsible for freeing it. */
+struct s0_environment_type *
+s0_yaml_document_parse_environment_type(struct s0_yaml_node node);
 
 
 #ifdef __cplusplus

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -604,6 +604,10 @@ struct s0_environment_type_mapping_entry {
 struct s0_environment_type_mapping *
 s0_environment_type_mapping_new(void);
 
+struct s0_environment_type_mapping *
+s0_environment_type_mapping_new_copy(
+        const struct s0_environment_type_mapping *other);
+
 void
 s0_environment_type_mapping_free(struct s0_environment_type_mapping *);
 

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -475,9 +475,16 @@ s0_entity_type_free(struct s0_entity_type *);
 enum s0_entity_type_kind
 s0_entity_type_kind(const struct s0_entity_type *);
 
+/* Returns whether the entity is an instance of the type (entity ∈ type). */
 bool
 s0_entity_type_satisfied_by(const struct s0_entity_type *,
                             const struct s0_entity *);
+
+/* Returns whether any entity that satisfies `have` would also satisfy
+ * `requires` (have ⊆ requires). */
+bool
+s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
+                                 const struct s0_entity_type *have);
 
 
 struct s0_entity_type *
@@ -585,9 +592,20 @@ int
 s0_environment_type_add_internal_inputs(struct s0_environment_type *,
                                         const struct s0_name_mapping *inputs);
 
+/* Returns whether an environment satisfies a type (env ∈ type).  We're stricter
+ * than you might expect!  The set of names in the type and environment must be
+ * exactly the same, and each entry in the environment must satisfy the
+ * corresponding entity type. */
 bool
 s0_environment_type_satisfied_by(const struct s0_environment_type *,
                                  const struct s0_environment *);
+
+/* Returns whether every environment that satisfies `have` would also satsify
+ * `requires` (have ⊆ requires). */
+bool
+s0_environment_type_satisfied_by_type(
+        const struct s0_environment_type *requires,
+        const struct s0_environment_type *have);
 
 
 /*-----------------------------------------------------------------------------

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1816,12 +1816,13 @@ s0_environment_type_add_create_closure(struct s0_environment_type *type,
         return -1;
     }
 
-    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    dest_name = s0_name_new_copy(stmt->_.create_closure.dest);
     if (unlikely(dest_name == NULL)) {
         return -1;
     }
 
-    dest_type = s0_any_entity_type_new();
+    dest_type = s0_closure_entity_type_new_from_named_blocks
+        (stmt->_.create_closure.branches);
     if (unlikely(dest_type == NULL)) {
         s0_name_free(dest_name);
         return -1;
@@ -1842,7 +1843,7 @@ s0_environment_type_add_create_literal(struct s0_environment_type *type,
         return -1;
     }
 
-    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    dest_name = s0_name_new_copy(stmt->_.create_literal.dest);
     if (unlikely(dest_name == NULL)) {
         return -1;
     }
@@ -1868,7 +1869,7 @@ s0_environment_type_add_create_method(struct s0_environment_type *type,
         return -1;
     }
 
-    dest_name = s0_name_new_copy(stmt->_.create_atom.dest);
+    dest_name = s0_name_new_copy(stmt->_.create_method.dest);
     if (unlikely(dest_name == NULL)) {
         return -1;
     }

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -13,13 +13,146 @@
 
 
 /*-----------------------------------------------------------------------------
- * Names
+ * Structs
  */
 
 struct s0_name {
     size_t  size;
     const void  *content;
 };
+
+struct s0_name_set {
+    size_t  size;
+    size_t  allocated_size;
+    struct s0_name  **names;
+};
+
+struct s0_name_mapping {
+    size_t  size;
+    size_t  allocated_size;
+    struct s0_name_mapping_entry  *entries;
+};
+
+struct s0_environment_entry {
+    struct s0_environment_entry  *next;
+    struct s0_name  *name;
+    struct s0_entity  *entity;
+};
+
+struct s0_environment {
+    struct s0_environment_entry  *head;
+    size_t  size;
+};
+
+struct s0_block {
+    struct s0_name_mapping  *inputs;
+    struct s0_statement_list  *statements;
+    struct s0_invocation  *invocation;
+};
+
+struct s0_named_blocks_entry {
+    struct s0_named_blocks_entry  *next;
+    struct s0_name  *name;
+    struct s0_block  *block;
+};
+
+struct s0_named_blocks {
+    struct s0_named_blocks_entry  *head;
+    size_t  size;
+};
+
+struct s0_statement {
+    enum s0_statement_kind  type;
+    union {
+        struct {
+            struct s0_name  *dest;
+        } create_atom;
+        struct {
+            struct s0_name  *dest;
+            struct s0_name_set  *closed_over;
+            struct s0_named_blocks  *branches;
+        } create_closure;
+        struct {
+            struct s0_name  *dest;
+            size_t  size;
+            const void  *content;
+        } create_literal;
+        struct {
+            struct s0_name  *dest;
+            struct s0_name  *self_input;
+            struct s0_block  *body;
+        } create_method;
+    } _;
+};
+
+struct s0_statement_list {
+    size_t  size;
+    size_t  allocated_size;
+    struct s0_statement  **statements;
+};
+
+struct s0_invocation {
+    enum s0_invocation_kind  type;
+    union {
+        struct {
+            struct s0_name  *src;
+            struct s0_name  *branch;
+        } invoke_closure;
+        struct {
+            struct s0_name  *src;
+            struct s0_name  *method;
+        } invoke_method;
+    } _;
+};
+
+struct s0_entity {
+    enum s0_entity_kind  type;
+    union {
+        struct {
+            struct s0_environment  *env;
+            struct s0_named_blocks  *blocks;
+        } closure;
+        struct {
+            size_t  size;
+            const void  *content;
+        } literal;
+        struct {
+            struct s0_name  *self_name;
+            struct s0_block  *block;
+        } method;
+        struct {
+            size_t  size;
+            size_t  allocated_size;
+            struct s0_object_entry  *entries;
+        } obj;
+    } _;
+};
+
+struct s0_entity_type {
+    enum s0_entity_type_kind  kind;
+    union {
+        struct {
+            struct s0_environment_type_mapping  *branches;
+        } closure;
+    } _;
+};
+
+struct s0_environment_type {
+    size_t  size;
+    size_t  allocated_size;
+    struct s0_environment_type_entry  *entries;
+};
+
+struct s0_environment_type_mapping {
+    size_t  size;
+    size_t  allocated_size;
+    struct s0_environment_type_mapping_entry  *entries;
+};
+
+
+/*-----------------------------------------------------------------------------
+ * Names
+ */
 
 struct s0_name *
 s0_name_new(size_t size, const void *content)
@@ -88,12 +221,6 @@ s0_name_eq(const struct s0_name *n1, const struct s0_name *n2)
 /*-----------------------------------------------------------------------------
  * Name sets
  */
-
-struct s0_name_set {
-    size_t  size;
-    size_t  allocated_size;
-    struct s0_name  **names;
-};
 
 #define DEFAULT_INITIAL_NAME_SET_SIZE  4
 
@@ -183,12 +310,6 @@ s0_name_set_at(const struct s0_name_set *set, size_t index)
 /*-----------------------------------------------------------------------------
  * Name mappings
  */
-
-struct s0_name_mapping {
-    size_t  size;
-    size_t  allocated_size;
-    struct s0_name_mapping_entry  *entries;
-};
 
 #define DEFAULT_INITIAL_NAME_MAPPING_SIZE  4
 
@@ -296,17 +417,6 @@ s0_name_mapping_get_from(const struct s0_name_mapping *mapping,
  * Environments
  */
 
-struct s0_environment_entry {
-    struct s0_environment_entry  *next;
-    struct s0_name  *name;
-    struct s0_entity  *entity;
-};
-
-struct s0_environment {
-    struct s0_environment_entry  *head;
-    size_t  size;
-};
-
 struct s0_environment *
 s0_environment_new(void)
 {
@@ -412,12 +522,6 @@ s0_environment_delete(struct s0_environment *env, const struct s0_name *name)
  * S₀: Blocks
  */
 
-struct s0_block {
-    struct s0_name_mapping  *inputs;
-    struct s0_statement_list  *statements;
-    struct s0_invocation  *invocation;
-};
-
 struct s0_block *
 s0_block_new(struct s0_name_mapping *inputs,
              struct s0_statement_list *statements,
@@ -468,16 +572,6 @@ s0_block_invocation(const struct s0_block *block)
  * Named blocks
  */
 
-struct s0_named_blocks_entry {
-    struct s0_named_blocks_entry  *next;
-    struct s0_name  *name;
-    struct s0_block  *block;
-};
-
-struct s0_named_blocks {
-    struct s0_named_blocks_entry  *head;
-};
-
 struct s0_named_blocks *
 s0_named_blocks_new(void)
 {
@@ -486,6 +580,7 @@ s0_named_blocks_new(void)
         return NULL;
     }
     blocks->head = NULL;
+    blocks->size = 0;
     return blocks;
 }
 
@@ -540,6 +635,7 @@ s0_named_blocks_add(struct s0_named_blocks *blocks,
     entry->block = block;
     entry->next = blocks->head;
     blocks->head = entry;
+    blocks->size++;
     return 0;
 }
 
@@ -560,31 +656,6 @@ s0_named_blocks_get(const struct s0_named_blocks *blocks,
 /*-----------------------------------------------------------------------------
  * Statements
  */
-
-struct s0_statement {
-    enum s0_statement_kind  type;
-    union {
-        struct {
-            struct s0_name  *dest;
-        } create_atom;
-        struct {
-            struct s0_name  *dest;
-            struct s0_name_set  *closed_over;
-            struct s0_named_blocks  *branches;
-        } create_closure;
-        struct {
-            struct s0_name  *dest;
-            size_t  size;
-            const void  *content;
-        } create_literal;
-        struct {
-            struct s0_name  *dest;
-            struct s0_name  *self_input;
-            struct s0_block  *body;
-        } create_method;
-    } _;
-};
-
 
 struct s0_statement *
 s0_create_atom_new(struct s0_name *dest)
@@ -793,12 +864,6 @@ s0_statement_kind(const struct s0_statement *stmt)
  * Statement lists
  */
 
-struct s0_statement_list {
-    size_t  size;
-    size_t  allocated_size;
-    struct s0_statement  **statements;
-};
-
 #define DEFAULT_INITIAL_STATEMENT_LIST_SIZE  4
 
 struct s0_statement_list *
@@ -867,21 +932,6 @@ s0_statement_list_at(const struct s0_statement_list *list, size_t index)
 /*-----------------------------------------------------------------------------
  * Invocations
  */
-
-struct s0_invocation {
-    enum s0_invocation_kind  type;
-    union {
-        struct {
-            struct s0_name  *src;
-            struct s0_name  *branch;
-        } invoke_closure;
-        struct {
-            struct s0_name  *src;
-            struct s0_name  *method;
-        } invoke_method;
-    } _;
-};
-
 
 struct s0_invocation *
 s0_invoke_closure_new(struct s0_name *src, struct s0_name *branch)
@@ -984,30 +1034,6 @@ s0_invocation_kind(const struct s0_invocation *invocation)
 /*-----------------------------------------------------------------------------
  * Entities
  */
-
-struct s0_entity {
-    enum s0_entity_kind  type;
-    union {
-        struct {
-            struct s0_environment  *env;
-            struct s0_named_blocks  *blocks;
-        } closure;
-        struct {
-            size_t  size;
-            const void  *content;
-        } literal;
-        struct {
-            struct s0_name  *self_name;
-            struct s0_block  *block;
-        } method;
-        struct {
-            size_t  size;
-            size_t  allocated_size;
-            struct s0_object_entry  *entries;
-        } obj;
-    } _;
-};
-
 
 struct s0_entity *
 s0_atom_new(void)
@@ -1278,19 +1304,15 @@ s0_entity_kind(const struct s0_entity *entity)
  * S₀: Entity types
  */
 
-struct s0_entity_type {
-    enum s0_entity_type_kind  kind;
-};
-
 struct s0_entity_type *
 s0_any_entity_type_new(void)
 {
-    struct s0_entity_type  *any = malloc(sizeof(struct s0_entity_type));
-    if (unlikely(any == NULL)) {
+    struct s0_entity_type  *type = malloc(sizeof(struct s0_entity_type));
+    if (unlikely(type == NULL)) {
         return NULL;
     }
-    any->kind = S0_ENTITY_TYPE_KIND_ANY;
-    return any;
+    type->kind = S0_ENTITY_TYPE_KIND_ANY;
+    return type;
 }
 
 static struct s0_entity_type *
@@ -1300,13 +1322,13 @@ s0_any_entity_type_new_copy(const struct s0_entity_type *other)
 }
 
 static void
-s0_any_entity_type_free(struct s0_entity_type *any)
+s0_any_entity_type_free(struct s0_entity_type *type)
 {
     /* Nothing to do */
 }
 
 static bool
-s0_any_entity_type_satisfied_by(const struct s0_entity_type *any,
+s0_any_entity_type_satisfied_by(const struct s0_entity_type *type,
                                 const struct s0_entity *entity)
 {
     return true;
@@ -1321,11 +1343,190 @@ s0_any_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
 
 
 struct s0_entity_type *
+s0_closure_entity_type_new(struct s0_environment_type_mapping *branches)
+{
+    struct s0_entity_type  *type = malloc(sizeof(struct s0_entity_type));
+    if (unlikely(type == NULL)) {
+        s0_environment_type_mapping_free(branches);
+        return NULL;
+    }
+    type->kind = S0_ENTITY_TYPE_KIND_CLOSURE;
+    type->_.closure.branches = branches;
+    return type;
+}
+
+struct s0_entity_type *
+s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks)
+{
+    struct s0_environment_type_mapping  *branches;
+    struct s0_named_blocks_entry  *curr;
+
+    branches = s0_environment_type_mapping_new();
+    if (unlikely(branches == NULL)) {
+        return NULL;
+    }
+
+    for (curr = blocks->head; curr != NULL; curr = curr->next) {
+        int  rc;
+        struct s0_name_mapping  *inputs = curr->block->inputs;
+        struct s0_name  *name_copy;
+        struct s0_environment_type  *branch_type;
+
+        name_copy = s0_name_new_copy(curr->name);
+        if (unlikely(name_copy == NULL)) {
+            s0_environment_type_mapping_free(branches);
+            return NULL;
+        }
+
+        branch_type = s0_environment_type_new();
+        if (unlikely(branch_type == NULL)) {
+            s0_name_free(name_copy);
+            s0_environment_type_mapping_free(branches);
+            return NULL;
+        }
+
+        rc = s0_environment_type_add_external_inputs(branch_type, inputs);
+        if (unlikely(rc != 0)) {
+            s0_name_free(name_copy);
+            s0_environment_type_free(branch_type);
+            s0_environment_type_mapping_free(branches);
+            return NULL;
+        }
+
+        rc = s0_environment_type_mapping_add(branches, name_copy, branch_type);
+        if (unlikely(rc != 0)) {
+            s0_environment_type_mapping_free(branches);
+            return NULL;
+        }
+    }
+
+    return s0_closure_entity_type_new(branches);
+}
+
+struct s0_entity_type *
+s0_closure_entity_type_new_from_closure(struct s0_entity *entity)
+{
+    assert(entity->type == S0_ENTITY_KIND_CLOSURE);
+    return s0_closure_entity_type_new_from_named_blocks
+        (entity->_.closure.blocks);
+}
+
+static struct s0_entity_type *
+s0_closure_entity_type_new_copy(const struct s0_entity_type *other)
+{
+    struct s0_environment_type_mapping  *branches_copy =
+        s0_environment_type_mapping_new_copy(other->_.closure.branches);
+    if (unlikely(branches_copy == NULL)) {
+        return NULL;
+    }
+    return s0_closure_entity_type_new(branches_copy);
+}
+
+static void
+s0_closure_entity_type_free(struct s0_entity_type *type)
+{
+    s0_environment_type_mapping_free(type->_.closure.branches);
+}
+
+static bool
+s0_closure_entity_type_satisfied_by(const struct s0_entity_type *type,
+                                    const struct s0_entity *entity)
+{
+    size_t  i;
+    struct s0_environment_type_mapping  *branches;
+    struct s0_named_blocks  *blocks;
+
+    if (entity->type != S0_ENTITY_KIND_CLOSURE) {
+        return false;
+    }
+
+    branches = type->_.closure.branches;
+    blocks = entity->_.closure.blocks;
+
+    if (branches->size != blocks->size) {
+        return false;
+    }
+
+    for (i = 0; i < branches->size; i++) {
+        int  rc;
+        struct s0_name  *name = branches->entries[i].name;
+        struct s0_environment_type  *type = branches->entries[i].type;
+        struct s0_block  *block;
+        struct s0_name_mapping  *block_inputs;
+        struct s0_environment_type  *block_type;
+
+        block = s0_named_blocks_get(blocks, name);
+        if (block == NULL) {
+            return false;
+        }
+
+        block_inputs = s0_block_inputs(block);
+        block_type = s0_environment_type_new();
+        rc = s0_environment_type_add_external_inputs(block_type, block_inputs);
+        if (unlikely(rc != 0)) {
+            s0_environment_type_free(block_type);
+            return false;
+        }
+
+        if (!s0_environment_type_satisfied_by_type(type, block_type)) {
+            s0_environment_type_free(block_type);
+            return false;
+        }
+
+        s0_environment_type_free(block_type);
+    }
+
+    return true;
+}
+
+static bool
+s0_closure_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
+                                         const struct s0_entity_type *have)
+{
+    size_t  i;
+    struct s0_environment_type_mapping  *requires_branches;
+    struct s0_environment_type_mapping  *have_branches;
+
+    if (have->kind != S0_ENTITY_TYPE_KIND_CLOSURE) {
+        return false;
+    }
+
+    requires_branches = requires->_.closure.branches;
+    have_branches = have->_.closure.branches;
+
+    if (requires_branches->size != have_branches->size) {
+        return false;
+    }
+
+    for (i = 0; i < requires_branches->size; i++) {
+        struct s0_name  *name = requires_branches->entries[i].name;
+        struct s0_environment_type  *requires_type =
+            requires_branches->entries[i].type;
+        struct s0_environment_type  *have_type;
+
+        have_type = s0_environment_type_mapping_get(have_branches, name);
+        if (have_type == NULL) {
+            return false;
+        }
+
+        if (!s0_environment_type_satisfied_by_type(requires_type, have_type)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+struct s0_entity_type *
 s0_entity_type_new_copy(const struct s0_entity_type *other)
 {
     switch (other->kind) {
         case S0_ENTITY_TYPE_KIND_ANY:
             return s0_any_entity_type_new_copy(other);
+            break;
+        case S0_ENTITY_TYPE_KIND_CLOSURE:
+            return s0_closure_entity_type_new_copy(other);
             break;
         default:
             assert(false);
@@ -1339,6 +1540,9 @@ s0_entity_type_free(struct s0_entity_type *type)
     switch (type->kind) {
         case S0_ENTITY_TYPE_KIND_ANY:
             s0_any_entity_type_free(type);
+            break;
+        case S0_ENTITY_TYPE_KIND_CLOSURE:
+            s0_closure_entity_type_free(type);
             break;
         default:
             assert(false);
@@ -1361,6 +1565,9 @@ s0_entity_type_satisfied_by(const struct s0_entity_type *type,
         case S0_ENTITY_TYPE_KIND_ANY:
             return s0_any_entity_type_satisfied_by(type, entity);
             break;
+        case S0_ENTITY_TYPE_KIND_CLOSURE:
+            return s0_closure_entity_type_satisfied_by(type, entity);
+            break;
         default:
             assert(false);
             break;
@@ -1375,6 +1582,9 @@ s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
         case S0_ENTITY_TYPE_KIND_ANY:
             return s0_any_entity_type_satisfied_by_type(requires, have);
             break;
+        case S0_ENTITY_TYPE_KIND_CLOSURE:
+            return s0_closure_entity_type_satisfied_by_type(requires, have);
+            break;
         default:
             assert(false);
             break;
@@ -1385,12 +1595,6 @@ s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
 /*-----------------------------------------------------------------------------
  * S₀: Environment types
  */
-
-struct s0_environment_type {
-    size_t  size;
-    size_t  allocated_size;
-    struct s0_environment_type_entry  *entries;
-};
 
 #define DEFAULT_INITIAL_ENVIRONMENT_TYPE_SIZE  4
 
@@ -1854,12 +2058,6 @@ s0_environment_type_satisfied_by_type(
 /*-----------------------------------------------------------------------------
  * Environment type mappings
  */
-
-struct s0_environment_type_mapping {
-    size_t  size;
-    size_t  allocated_size;
-    struct s0_environment_type_mapping_entry  *entries;
-};
 
 #define DEFAULT_INITIAL_ENVIRONMENT_TYPE_MAPPING_SIZE  4
 

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1837,6 +1837,44 @@ s0_environment_type_mapping_new(void)
     return mapping;
 }
 
+struct s0_environment_type_mapping *
+s0_environment_type_mapping_new_copy(
+        const struct s0_environment_type_mapping *other)
+{
+    size_t  i;
+    struct s0_environment_type_mapping  *mapping =
+        s0_environment_type_mapping_new();
+    if (unlikely(mapping == NULL)) {
+        return NULL;
+    }
+
+    for (i = 0; i < other->size; i++) {
+        int  rc;
+        struct s0_name  *name_copy;
+        struct s0_environment_type  *type_copy;
+
+        name_copy = s0_name_new_copy(other->entries[i].name);
+        if (unlikely(name_copy == NULL)) {
+            s0_environment_type_mapping_free(mapping);
+            return NULL;
+        }
+
+        type_copy = s0_environment_type_new_copy(other->entries[i].type);
+        if (unlikely(type_copy == NULL)) {
+            s0_name_free(name_copy);
+            s0_environment_type_mapping_free(mapping);
+            return NULL;
+        }
+
+        rc = s0_environment_type_mapping_add(mapping, name_copy, type_copy);
+        if (unlikely(rc != 0)) {
+            s0_environment_type_mapping_free(mapping);
+            return NULL;
+        }
+    }
+    return mapping;
+}
+
 void
 s0_environment_type_mapping_free(struct s0_environment_type_mapping *mapping)
 {

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1312,6 +1312,14 @@ s0_any_entity_type_satisfied_by(const struct s0_entity_type *any,
     return true;
 }
 
+static bool
+s0_any_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
+                                     const struct s0_entity_type *have)
+{
+    return true;
+}
+
+
 struct s0_entity_type *
 s0_entity_type_new_copy(const struct s0_entity_type *other)
 {
@@ -1352,6 +1360,20 @@ s0_entity_type_satisfied_by(const struct s0_entity_type *type,
     switch (type->kind) {
         case S0_ENTITY_TYPE_KIND_ANY:
             return s0_any_entity_type_satisfied_by(type, entity);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+}
+
+bool
+s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
+                                 const struct s0_entity_type *have)
+{
+    switch (requires->kind) {
+        case S0_ENTITY_TYPE_KIND_ANY:
+            return s0_any_entity_type_satisfied_by_type(requires, have);
             break;
         default:
             assert(false);
@@ -1797,6 +1819,30 @@ s0_environment_type_satisfied_by(const struct s0_environment_type *type,
         const struct s0_entity_type  *etype = type->entries[i].type;
         struct s0_entity  *element = s0_environment_get(env, name);
         if (element == NULL || !s0_entity_type_satisfied_by(etype, element)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool
+s0_environment_type_satisfied_by_type(
+        const struct s0_environment_type *requires,
+        const struct s0_environment_type *have)
+{
+    size_t  i;
+
+    if (requires->size != have->size) {
+        return false;
+    }
+
+    for (i = 0; i < requires->size; i++) {
+        const struct s0_name  *name = requires->entries[i].name;
+        const struct s0_entity_type  *rtype = requires->entries[i].type;
+        const struct s0_entity_type  *htype =
+            s0_environment_type_get(have, name);
+        if (htype == NULL || !s0_entity_type_satisfied_by_type(rtype, htype)) {
             return false;
         }
     }

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1392,6 +1392,42 @@ s0_environment_type_new(void)
     return type;
 }
 
+struct s0_environment_type *
+s0_environment_type_new_copy(const struct s0_environment_type *other)
+{
+    size_t  i;
+    struct s0_environment_type  *type = s0_environment_type_new();
+    if (unlikely(type == NULL)) {
+        return NULL;
+    }
+
+    for (i = 0; i < other->size; i++) {
+        int  rc;
+        struct s0_name  *name_copy;
+        struct s0_entity_type  *type_copy;
+
+        name_copy = s0_name_new_copy(other->entries[i].name);
+        if (unlikely(name_copy == NULL)) {
+            s0_environment_type_free(type);
+            return NULL;
+        }
+
+        type_copy = s0_entity_type_new_copy(other->entries[i].type);
+        if (unlikely(type_copy == NULL)) {
+            s0_name_free(name_copy);
+            s0_environment_type_free(type);
+            return NULL;
+        }
+
+        rc = s0_environment_type_add(type, name_copy, type_copy);
+        if (unlikely(rc != 0)) {
+            s0_environment_type_free(type);
+            return NULL;
+        }
+    }
+    return type;
+}
+
 void
 s0_environment_type_free(struct s0_environment_type *type)
 {

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1591,6 +1591,14 @@ s0_entity_type_satisfied_by_type(const struct s0_entity_type *requires,
     }
 }
 
+bool
+s0_entity_type_equiv(const struct s0_entity_type *type1,
+                     const struct s0_entity_type *type2)
+{
+    return s0_entity_type_satisfied_by_type(type1, type2)
+        && s0_entity_type_satisfied_by_type(type2, type1);
+}
+
 
 /*-----------------------------------------------------------------------------
  * S₀: Environment types
@@ -2052,6 +2060,14 @@ s0_environment_type_satisfied_by_type(
     }
 
     return true;
+}
+
+bool
+s0_environment_type_equiv(const struct s0_environment_type *type1,
+                          const struct s0_environment_type *type2)
+{
+    return s0_environment_type_satisfied_by_type(type1, type2)
+        && s0_environment_type_satisfied_by_type(type2, type1);
 }
 
 

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1907,10 +1907,28 @@ s0_environment_type_add_invoke_closure(struct s0_environment_type *type,
                                        const struct s0_invocation *invocation)
 {
     struct s0_entity_type  *src_type;
+    struct s0_environment_type  *branch_inputs;
 
     src_type = s0_environment_type_delete
         (type, invocation->_.invoke_closure.src);
     if (unlikely(src_type == NULL)) {
+        return -1;
+    }
+
+    if (src_type->kind != S0_ENTITY_TYPE_KIND_CLOSURE) {
+        s0_entity_type_free(src_type);
+        return -1;
+    }
+
+    branch_inputs = s0_environment_type_mapping_get
+        (src_type->_.closure.branches, invocation->_.invoke_closure.branch);
+    if (branch_inputs == NULL) {
+        s0_entity_type_free(src_type);
+        return -1;
+    }
+
+    if (!s0_environment_type_satisfied_by_type(branch_inputs, type)) {
+        s0_entity_type_free(src_type);
         return -1;
     }
 

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1631,6 +1631,53 @@ s0_environment_type_add_statement(struct s0_environment_type *type,
     }
 }
 
+static int
+s0_environment_type_add_invoke_closure(struct s0_environment_type *type,
+                                       const struct s0_invocation *invocation)
+{
+    struct s0_entity_type  *src_type;
+
+    src_type = s0_environment_type_delete
+        (type, invocation->_.invoke_closure.src);
+    if (unlikely(src_type == NULL)) {
+        return -1;
+    }
+
+    s0_entity_type_free(src_type);
+    return 0;
+}
+
+static int
+s0_environment_type_add_invoke_method(struct s0_environment_type *type,
+                                      const struct s0_invocation *invocation)
+{
+    struct s0_entity_type  *src_type;
+
+    src_type = s0_environment_type_delete
+        (type, invocation->_.invoke_method.src);
+    if (unlikely(src_type == NULL)) {
+        return -1;
+    }
+
+    s0_entity_type_free(src_type);
+    return 0;
+}
+
+int
+s0_environment_type_add_invocation(struct s0_environment_type *type,
+                                   const struct s0_invocation *invocation)
+{
+    switch (invocation->type) {
+        case S0_INVOCATION_KIND_INVOKE_CLOSURE:
+            return s0_environment_type_add_invoke_closure(type, invocation);
+        case S0_INVOCATION_KIND_INVOKE_METHOD:
+            return s0_environment_type_add_invoke_method(type, invocation);
+        default:
+            assert(false);
+            break;
+    }
+}
+
 int
 s0_environment_type_add_external_inputs(struct s0_environment_type *type,
                                         const struct s0_name_mapping *inputs)

--- a/c/tests/test-cases.h
+++ b/c/tests/test-cases.h
@@ -103,11 +103,13 @@ shorten_filename(const char *filename)
 static void
 fail_at(const char *msg, const char *filename, unsigned int line)
 {
+    if (!test_case_failed) {
+        printf("not ok %u - %s\n", test_case_number,
+               current_test_case->description);
+    }
+    printf("# %s at %s:%u\n", msg, shorten_filename(filename), line);
     test_case_failed = true;
     any_test_case_failed = true;
-    printf("not ok %u - %s\n", test_case_number,
-           current_test_case->description);
-    printf("# %s at %s:%u\n", msg, shorten_filename(filename), line);
 }
 
 static void
@@ -165,6 +167,8 @@ exit_status(void)
 /*-----------------------------------------------------------------------------
  * Helper macros
  */
+
+#define fail(msg)  fail_at(msg, __FILE__, __LINE__)
 
 #define check_alloc_with_msg(var, call, msg) \
     do { \

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1017,7 +1017,7 @@ TEST_CASE("can copy `any` type") {
     s0_entity_type_free(any2);
 }
 
-TEST_CASE("atom : any") {
+TEST_CASE("⋄ ∈ *") {
     struct s0_entity_type  *any;
     struct s0_entity  *entity;
     check_alloc(any, s0_any_entity_type_new());
@@ -1027,7 +1027,7 @@ TEST_CASE("atom : any") {
     s0_entity_type_free(any);
 }
 
-TEST_CASE("closure : any") {
+TEST_CASE("closure ∈ *") {
     struct s0_entity_type  *any;
     struct s0_environment  *env;
     struct s0_named_blocks  *blocks;
@@ -1041,7 +1041,7 @@ TEST_CASE("closure : any") {
     s0_entity_type_free(any);
 }
 
-TEST_CASE("literal : any") {
+TEST_CASE("literal ∈ *") {
     struct s0_entity_type  *any;
     struct s0_entity  *entity;
     check_alloc(any, s0_any_entity_type_new());
@@ -1051,7 +1051,7 @@ TEST_CASE("literal : any") {
     s0_entity_type_free(any);
 }
 
-TEST_CASE("method : any") {
+TEST_CASE("method ∈ *") {
     struct s0_entity_type  *any;
     struct s0_name  *self_name;
     struct s0_block  *block;
@@ -1065,7 +1065,7 @@ TEST_CASE("method : any") {
     s0_entity_type_free(any);
 }
 
-TEST_CASE("object : any") {
+TEST_CASE("object ∈ *") {
     struct s0_entity_type  *any;
     struct s0_entity  *entity;
     check_alloc(any, s0_any_entity_type_new());
@@ -1073,6 +1073,16 @@ TEST_CASE("object : any") {
     check(s0_entity_type_satisfied_by(any, entity));
     s0_entity_free(entity);
     s0_entity_type_free(any);
+}
+
+TEST_CASE("* ⊆ *") {
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    check_alloc(requires, s0_any_entity_type_new());
+    check_alloc(have, s0_any_entity_type_new());
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
 }
 
 /*-----------------------------------------------------------------------------
@@ -1168,7 +1178,7 @@ TEST_CASE("can copy environment type") {
     struct s0_name  *name;
     struct s0_entity_type  *etype;
 
-    /* Construct {a: any, b: any} and then make a copy of it. */
+    /* Construct ⦃a:*, b:*⦄ and then make a copy of it. */
     check_alloc(type, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype, s0_any_entity_type_new());
@@ -1251,7 +1261,7 @@ TEST_CASE("can extract entries from environment type") {
     struct s0_entity_type  *etype2;
     struct s0_name_set  *set;
 
-    /* Construct {a: any, b: any} */
+    /* Construct ⦃a:*, b:*⦄ */
     check_alloc(src, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype1, s0_any_entity_type_new());
@@ -1268,7 +1278,7 @@ TEST_CASE("can extract entries from environment type") {
     check0(s0_environment_type_extract(dest, src, set));
     s0_name_set_free(set);
 
-    /* Verify that dest == {b: any} */
+    /* Verify that dest == ⦃b:*⦄ */
     check(s0_environment_type_size(dest) == 1);
     check_alloc(name, s0_name_new_str("a"));
     check(s0_environment_type_get(dest, name) == etype1);
@@ -1277,7 +1287,7 @@ TEST_CASE("can extract entries from environment type") {
     check(s0_environment_type_get(dest, name) == NULL);
     s0_name_free(name);
 
-    /* Verify that src == {b: any} */
+    /* Verify that src == ⦃b:*⦄ */
     check(s0_environment_type_size(src) == 1);
     check_alloc(name, s0_name_new_str("a"));
     check(s0_environment_type_get(src, name) == NULL);
@@ -1297,7 +1307,7 @@ TEST_CASE("cannot extract duplicate entries from environment type") {
     struct s0_entity_type  *etype;
     struct s0_name_set  *set;
 
-    /* Construct {a: any, b: any} */
+    /* Construct ⦃a:*, b:*⦄ */
     check_alloc(src, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype, s0_any_entity_type_new());
@@ -1361,22 +1371,28 @@ TEST_CASE("cannot iterate deleted entries from environment type") {
     s0_environment_type_free(type);
 }
 
-TEST_CASE("env() : {}") {
+TEST_CASE("{} ∈ ⦃⦄") {
     struct s0_environment_type  *type;
     struct s0_environment  *env;
+    /* type = ⦃⦄ */
     check_alloc(type, s0_environment_type_new());
+    /* env = {} */
     check_alloc(env, s0_environment_new());
+    /* Verify {} ∈ ⦃⦄ */
     check(s0_environment_type_satisfied_by(type, env));
+    /* Free everything */
     s0_environment_type_free(type);
     s0_environment_free(env);
 }
 
-TEST_CASE("env(a,b) !: {}") {
+TEST_CASE("{a:⋄, b:⋄} ∉ ⦃⦄") {
     struct s0_name  *name;
     struct s0_environment_type  *type;
     struct s0_environment  *env;
     struct s0_entity  *atom;
+    /* type = ⦃⦄ */
     check_alloc(type, s0_environment_type_new());
+    /* env = {a:⋄, b:⋄} */
     check_alloc(env, s0_environment_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(atom, s0_atom_new());
@@ -1384,21 +1400,25 @@ TEST_CASE("env(a,b) !: {}") {
     check_alloc(name, s0_name_new_str("b"));
     check_alloc(atom, s0_atom_new());
     check0(s0_environment_add(env, name, atom));
+    /* Verify {a:⋄, b:⋄} ∈ ⦃⦄ */
     check(!s0_environment_type_satisfied_by(type, env));
+    /* Free everything */
     s0_environment_type_free(type);
     s0_environment_free(env);
 }
 
-TEST_CASE("env(a,b) !: {a: any}") {
+TEST_CASE("{a:⋄, b:⋄} ∉ ⦃a:*⦄") {
     struct s0_name  *name;
     struct s0_environment_type  *type;
     struct s0_entity_type  *etype;
     struct s0_environment  *env;
     struct s0_entity  *atom;
+    /* type = ⦃a:*⦄ */
     check_alloc(type, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_environment_type_add(type, name, etype));
+    /* env = {a:⋄, b:⋄} */
     check_alloc(env, s0_environment_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(atom, s0_atom_new());
@@ -1406,17 +1426,20 @@ TEST_CASE("env(a,b) !: {a: any}") {
     check_alloc(name, s0_name_new_str("b"));
     check_alloc(atom, s0_atom_new());
     check0(s0_environment_add(env, name, atom));
+    /* Verify {a:⋄, b:⋄} ∈ ⦃a:*⦄ */
     check(!s0_environment_type_satisfied_by(type, env));
+    /* Free everything */
     s0_environment_type_free(type);
     s0_environment_free(env);
 }
 
-TEST_CASE("env(a,b) : {a: any, b: any}") {
+TEST_CASE("{a:⋄, b:⋄} ∈ ⦃a:*, b:*⦄") {
     struct s0_name  *name;
     struct s0_environment_type  *type;
     struct s0_entity_type  *etype;
     struct s0_environment  *env;
     struct s0_entity  *atom;
+    /* type = ⦃a:*, b:*⦄ */
     check_alloc(type, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype, s0_any_entity_type_new());
@@ -1424,6 +1447,7 @@ TEST_CASE("env(a,b) : {a: any, b: any}") {
     check_alloc(name, s0_name_new_str("b"));
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_environment_type_add(type, name, etype));
+    /* env = {a:⋄, b:⋄} */
     check_alloc(env, s0_environment_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(atom, s0_atom_new());
@@ -1431,7 +1455,40 @@ TEST_CASE("env(a,b) : {a: any, b: any}") {
     check_alloc(name, s0_name_new_str("b"));
     check_alloc(atom, s0_atom_new());
     check0(s0_environment_add(env, name, atom));
+    /* Verify {a:⋄, b:⋄} ∈ ⦃a:*, b:*⦄ */
     check(s0_environment_type_satisfied_by(type, env));
+    /* Free everything */
+    s0_environment_type_free(type);
+    s0_environment_free(env);
+}
+
+TEST_CASE("{a:⋄, b:⋄} ∉ ⦃a:*, b:*, c:*⦄") {
+    struct s0_name  *name;
+    struct s0_environment_type  *type;
+    struct s0_entity_type  *etype;
+    struct s0_environment  *env;
+    struct s0_entity  *atom;
+    /* type = ⦃a:*, b:*, c:*⦄ */
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("c"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    /* env = {a:⋄, b:⋄} */
+    check_alloc(env, s0_environment_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(atom, s0_atom_new());
+    check0(s0_environment_add(env, name, atom));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(atom, s0_atom_new());
+    check0(s0_environment_add(env, name, atom));
+    /* Verify {a:⋄, b:⋄} ∈ ⦃a:*, b:*, c:*⦄ */
+    check(!s0_environment_type_satisfied_by(type, env));
     s0_environment_type_free(type);
     s0_environment_free(env);
 }
@@ -1583,7 +1640,7 @@ TEST_CASE("can create external environment type from input mappings") {
     check_alloc(type, s0_environment_type_new());
     check0(s0_environment_type_add_external_inputs(type, mapping));
 
-    /* Result should be {a: any, c: any} */
+    /* Result should be ⦃a:*, c:*⦄ */
     check(s0_environment_type_size(type) == 2);
     check_alloc(name, s0_name_new_str("a"));
     check_nonnull(etype = s0_environment_type_get(type, name));
@@ -1639,7 +1696,6 @@ TEST_CASE("can create internal environment type from input mappings") {
     struct s0_environment_type  *type;
     struct s0_name  *name;
     struct s0_entity_type  *etype;
-
     /* Create the mapping */
     check_alloc(mapping, s0_name_mapping_new());
     check_alloc(from, s0_name_new_str("a"));
@@ -1650,12 +1706,10 @@ TEST_CASE("can create internal environment type from input mappings") {
     check_alloc(to, s0_name_new_str("d"));
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_name_mapping_add(mapping, from, to, etype));
-
     /* Create an environment type from the mapping */
     check_alloc(type, s0_environment_type_new());
     check0(s0_environment_type_add_internal_inputs(type, mapping));
-
-    /* Result should be {b: any, d: any} */
+    /* Result should be ⦃b:*, d:*⦄ */
     check(s0_environment_type_size(type) == 2);
     check_alloc(name, s0_name_new_str("b"));
     check_nonnull(etype = s0_environment_type_get(type, name));
@@ -1665,7 +1719,7 @@ TEST_CASE("can create internal environment type from input mappings") {
     check_nonnull(etype = s0_environment_type_get(type, name));
     check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
     s0_name_free(name);
-
+    /* Free everything */
     s0_environment_type_free(type);
     s0_name_mapping_free(mapping);
 }
@@ -1677,7 +1731,6 @@ TEST_CASE("cannot overwrite internal environment type from input mappings") {
     struct s0_environment_type  *type;
     struct s0_name  *name;
     struct s0_entity_type  *etype;
-
     /* Create the mapping */
     check_alloc(mapping, s0_name_mapping_new());
     check_alloc(from, s0_name_new_str("a"));
@@ -1688,7 +1741,6 @@ TEST_CASE("cannot overwrite internal environment type from input mappings") {
     check_alloc(to, s0_name_new_str("d"));
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_name_mapping_add(mapping, from, to, etype));
-
     /* Create an environment type with entries that overlap what we'd add from
      * the mapping. */
     check_alloc(type, s0_environment_type_new());
@@ -1699,9 +1751,245 @@ TEST_CASE("cannot overwrite internal environment type from input mappings") {
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_environment_type_add(type, name, etype));
     check(s0_environment_type_add_internal_inputs(type, mapping) == -1);
-
+    /* Free everything */
     s0_environment_type_free(type);
     s0_name_mapping_free(mapping);
+}
+
+TEST_CASE("⦃⦄ ⊆ ⦃⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    /* requires = ⦃⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    /* have = ⦃⦄ */
+    check_alloc(have, s0_environment_type_new());
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃⦄ ⊈ ⦃a:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃⦄ */
+    check_alloc(have, s0_environment_type_new());
+    /* Verify have ⊈ requires */
+    check(!s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*⦄ ⊈ ⦃⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    /* have = ⦃a:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊈ requires */
+    check(!s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*⦄ ⊆ ⦃a:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃a:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*⦄ ⊈ ⦃a:*,b:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*,b:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃a:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊈ requires */
+    check(!s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*,b:*⦄ ⊈ ⦃a:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃a:*,b:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊈ requires */
+    check(!s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*,b:*⦄ ⊆ ⦃a:*,b:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*,b:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃a:*,b:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃a:*,b:*⦄ ⊆ ⦃b:*,a:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃b:*,a:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃a:*,b:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃b:*,a:*⦄ ⊆ ⦃a:*,b:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃a:*,b:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃b:*,a:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
+}
+
+TEST_CASE("⦃b:*,a:*⦄ ⊆ ⦃b:*,a:*⦄") {
+    struct s0_environment_type  *requires;
+    struct s0_environment_type  *have;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* requires = ⦃b:*,a:*⦄ */
+    check_alloc(requires, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(requires, name, etype));
+    /* have = ⦃b:*,a:*⦄ */
+    check_alloc(have, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(have, name, etype));
+    /* Verify have ⊆ requires */
+    check(s0_environment_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_environment_type_free(requires);
+    s0_environment_type_free(have);
 }
 
 /*-----------------------------------------------------------------------------

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1791,6 +1791,38 @@ TEST_CASE("can check which names belong to mapping") {
     s0_environment_type_mapping_free(mapping);
 }
 
+TEST_CASE("can copy environment type mapping") {
+    struct s0_environment_type_mapping  *mapping;
+    struct s0_environment_type_mapping  *mapping_copy;
+    struct s0_name  *name;
+    struct s0_environment_type  *type;
+
+    /* Create a mapping and then create a copy it it. */
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type));
+    check_alloc(mapping_copy, s0_environment_type_mapping_new_copy(mapping));
+    s0_environment_type_mapping_free(mapping);
+
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(s0_environment_type_mapping_get(mapping_copy, name));
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("b"));
+    check_nonnull(s0_environment_type_mapping_get(mapping_copy, name));
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("c"));
+    check(s0_environment_type_mapping_get(mapping_copy, name) == NULL);
+    s0_name_free(name);
+
+    s0_environment_type_mapping_free(mapping_copy);
+}
+
 TEST_CASE("can iterate through names in mapping") {
     struct s0_environment_type_mapping  *mapping;
     const struct s0_environment_type_mapping_entry  *entry;

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1671,6 +1671,125 @@ TEST_CASE("cannot overwrite internal environment type from input mappings") {
 }
 
 /*-----------------------------------------------------------------------------
+ * S₀: Environment type mappings
+ */
+
+TEST_CASE_GROUP("S₀ environment type mappings");
+
+TEST_CASE("can create empty environment type mapping") {
+    struct s0_environment_type_mapping  *mapping;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("empty environment type mapping has zero elements") {
+    struct s0_environment_type_mapping  *mapping;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check(s0_environment_type_mapping_size(mapping) == 0);
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("empty environment type mapping doesn't contain anything") {
+    struct s0_environment_type_mapping  *mapping;
+    struct s0_name  *name;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_mapping_get(mapping, name) == NULL);
+    s0_name_free(name);
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("can add environment types to mapping") {
+    struct s0_environment_type_mapping  *mapping;
+    struct s0_name  *name;
+    struct s0_environment_type  *type;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type));
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("non-empty environment type mapping has accurate size") {
+    struct s0_environment_type_mapping  *mapping;
+    struct s0_name  *name;
+    struct s0_environment_type  *type;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type));
+    check(s0_environment_type_mapping_size(mapping) == 1);
+
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(type, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type));
+    check(s0_environment_type_mapping_size(mapping) == 2);
+
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("can check which names belong to mapping") {
+    struct s0_environment_type_mapping  *mapping;
+    struct s0_name  *name;
+    struct s0_environment_type  *type1;
+    struct s0_environment_type  *type2;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(type1, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type1));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(type2, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type2));
+
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_mapping_get(mapping, name) == type1);
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("b"));
+    check(s0_environment_type_mapping_get(mapping, name) == type2);
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("c"));
+    check(s0_environment_type_mapping_get(mapping, name) == NULL);
+    s0_name_free(name);
+
+    s0_environment_type_mapping_free(mapping);
+}
+
+TEST_CASE("can iterate through names in mapping") {
+    struct s0_environment_type_mapping  *mapping;
+    const struct s0_environment_type_mapping_entry  *entry;
+    struct s0_name  *name;
+    struct s0_environment_type  *type1;
+    struct s0_environment_type  *type2;
+    check_alloc(mapping, s0_environment_type_mapping_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(type1, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type1));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(type2, s0_environment_type_new());
+    check0(s0_environment_type_mapping_add(mapping, name, type2));
+
+    /* This test assumes that the names are returned in the same order that they
+     * were added to the mapping. */
+
+    check_nonnull(entry = s0_environment_type_mapping_at(mapping, 0));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_name_eq(entry->name, name));
+    check(entry->type == type1);
+    s0_name_free(name);
+
+    check_nonnull(entry = s0_environment_type_mapping_at(mapping, 1));
+    check_alloc(name, s0_name_new_str("b"));
+    check(s0_name_eq(entry->name, name));
+    check(entry->type == type2);
+    s0_name_free(name);
+
+    s0_environment_type_mapping_free(mapping);
+}
+
+/*-----------------------------------------------------------------------------
  * Harness
  */
 

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1014,8 +1014,8 @@ TEST_CASE("can copy *") {
     check_alloc(type1, s0_any_entity_type_new());
     /* type2 = type1 */
     check_alloc(type2, s0_entity_type_new_copy(type1));
-    /* Verify (as much as we can) type1 == type2 */
-    check(s0_entity_type_kind(type1) == s0_entity_type_kind(type2));
+    /* Verify type1 == type2 */
+    check(s0_entity_type_equiv(type1, type2));
     /* Free everything */
     s0_entity_type_free(type1);
     s0_entity_type_free(type2);
@@ -1145,8 +1145,8 @@ TEST_CASE("can copy ⤿ ⦃a:*⦄") {
     check_alloc(type1, s0_closure_entity_type_new(branches));
     /* type2 = type1 */
     check_alloc(type2, s0_entity_type_new_copy(type1));
-    /* Verify (as much as we can) type1 == type2 */
-    check(s0_entity_type_kind(type1) == s0_entity_type_kind(type2));
+    /* Verify type1 == type2 */
+    check(s0_entity_type_equiv(type1, type2));
     /* Free everything */
     s0_entity_type_free(type1);
     s0_entity_type_free(type2);
@@ -1553,8 +1553,7 @@ TEST_CASE("can copy environment type") {
     struct s0_environment_type  *type_copy;
     struct s0_name  *name;
     struct s0_entity_type  *etype;
-
-    /* Construct ⦃a:*, b:*⦄ and then make a copy of it. */
+    /* Construct ⦃a:*, b:*⦄ */
     check_alloc(type, s0_environment_type_new());
     check_alloc(name, s0_name_new_str("a"));
     check_alloc(etype, s0_any_entity_type_new());
@@ -1562,23 +1561,12 @@ TEST_CASE("can copy environment type") {
     check_alloc(name, s0_name_new_str("b"));
     check_alloc(etype, s0_any_entity_type_new());
     check0(s0_environment_type_add(type, name, etype));
+    /* Make a copy of it */
     check_alloc(type_copy, s0_environment_type_new_copy(type));
+    /* Verify that they're equal */
+    check(s0_environment_type_equiv(type, type_copy));
+    /* Free everything */
     s0_environment_type_free(type);
-
-    check_alloc(name, s0_name_new_str("a"));
-    check_nonnull(etype = s0_environment_type_get(type_copy, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
-    s0_name_free(name);
-
-    check_alloc(name, s0_name_new_str("b"));
-    check_nonnull(etype = s0_environment_type_get(type_copy, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
-    s0_name_free(name);
-
-    check_alloc(name, s0_name_new_str("c"));
-    check(s0_environment_type_get(type_copy, name) == NULL);
-    s0_name_free(name);
-
     s0_environment_type_free(type_copy);
 }
 
@@ -1654,7 +1642,7 @@ TEST_CASE("can extract entries from environment type") {
     check0(s0_environment_type_extract(dest, src, set));
     s0_name_set_free(set);
 
-    /* Verify that dest == ⦃b:*⦄ */
+    /* Verify that dest == ⦃a:*⦄ */
     check(s0_environment_type_size(dest) == 1);
     check_alloc(name, s0_name_new_str("a"));
     check(s0_environment_type_get(dest, name) == etype1);

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1007,80 +1007,456 @@ TEST_CASE("can delete entries from environment") {
 
 TEST_CASE_GROUP("S₀ entity types: any");
 
-TEST_CASE("can copy `any` type") {
-    struct s0_entity_type  *any1;
-    struct s0_entity_type  *any2;
-    check_alloc(any1, s0_any_entity_type_new());
-    check_alloc(any2, s0_entity_type_new_copy(any1));
-    check(s0_entity_type_kind(any1) == s0_entity_type_kind(any2));
-    s0_entity_type_free(any1);
-    s0_entity_type_free(any2);
+TEST_CASE("can copy *") {
+    struct s0_entity_type  *type1;
+    struct s0_entity_type  *type2;
+    /* type1 = * */
+    check_alloc(type1, s0_any_entity_type_new());
+    /* type2 = type1 */
+    check_alloc(type2, s0_entity_type_new_copy(type1));
+    /* Verify (as much as we can) type1 == type2 */
+    check(s0_entity_type_kind(type1) == s0_entity_type_kind(type2));
+    /* Free everything */
+    s0_entity_type_free(type1);
+    s0_entity_type_free(type2);
 }
 
 TEST_CASE("⋄ ∈ *") {
-    struct s0_entity_type  *any;
+    struct s0_entity_type  *type;
     struct s0_entity  *entity;
-    check_alloc(any, s0_any_entity_type_new());
+    /* type = * */
+    check_alloc(type, s0_any_entity_type_new());
+    /* entity = ⋄ */
     check_alloc(entity, s0_atom_new());
-    check(s0_entity_type_satisfied_by(any, entity));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
     s0_entity_free(entity);
-    s0_entity_type_free(any);
+    s0_entity_type_free(type);
 }
 
-TEST_CASE("closure ∈ *") {
-    struct s0_entity_type  *any;
+TEST_CASE("⟨⤿ ⦃a:*⦄ ...⟩ ∈ *") {
+    struct s0_entity_type  *type;
     struct s0_environment  *env;
     struct s0_named_blocks  *blocks;
+    struct s0_name_mapping  *inputs;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_name  *name;
     struct s0_entity  *entity;
-    check_alloc(any, s0_any_entity_type_new());
+    /* type = * */
+    check_alloc(type, s0_any_entity_type_new());
+    /* entity = ⟨⤿ ⦃a:*⦄ ...⟩ */
     check_alloc(env, s0_environment_new());
     check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(inputs, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(inputs, from, to, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(invocation, s0_invoke_closure_new(src, branch));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_named_blocks_add(blocks, name, block));
     check_alloc(entity, s0_closure_new(env, blocks));
-    check(s0_entity_type_satisfied_by(any, entity));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
     s0_entity_free(entity);
-    s0_entity_type_free(any);
+    s0_entity_type_free(type);
 }
 
 TEST_CASE("literal ∈ *") {
-    struct s0_entity_type  *any;
+    struct s0_entity_type  *type;
     struct s0_entity  *entity;
-    check_alloc(any, s0_any_entity_type_new());
+    /* type = * */
+    check_alloc(type, s0_any_entity_type_new());
+    /* entity = literal */
     check_alloc(entity, s0_literal_new_str("hello"));
-    check(s0_entity_type_satisfied_by(any, entity));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
     s0_entity_free(entity);
-    s0_entity_type_free(any);
+    s0_entity_type_free(type);
 }
 
 TEST_CASE("method ∈ *") {
-    struct s0_entity_type  *any;
+    struct s0_entity_type  *type;
     struct s0_name  *self_name;
     struct s0_block  *block;
     struct s0_entity  *entity;
-    check_alloc(any, s0_any_entity_type_new());
+    /* type = * */
+    check_alloc(type, s0_any_entity_type_new());
+    /* entity = method */
     check_alloc(self_name, s0_name_new_str("self"));
     check_alloc(block, create_empty_block());
     check_alloc(entity, s0_method_new(self_name, block));
-    check(s0_entity_type_satisfied_by(any, entity));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
     s0_entity_free(entity);
-    s0_entity_type_free(any);
+    s0_entity_type_free(type);
 }
 
 TEST_CASE("object ∈ *") {
-    struct s0_entity_type  *any;
+    struct s0_entity_type  *type;
     struct s0_entity  *entity;
-    check_alloc(any, s0_any_entity_type_new());
+    /* type = * */
+    check_alloc(type, s0_any_entity_type_new());
+    /* entity = object */
     check_alloc(entity, s0_object_new());
-    check(s0_entity_type_satisfied_by(any, entity));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
     s0_entity_free(entity);
-    s0_entity_type_free(any);
+    s0_entity_type_free(type);
 }
+
+/*-----------------------------------------------------------------------------
+ * S₀: Entity types: Closures
+ */
+
+TEST_CASE_GROUP("S₀ entity types: closures");
+
+TEST_CASE("can copy ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type1;
+    struct s0_entity_type  *type2;
+    /* type1 = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type1, s0_closure_entity_type_new(branches));
+    /* type2 = type1 */
+    check_alloc(type2, s0_entity_type_new_copy(type1));
+    /* Verify (as much as we can) type1 == type2 */
+    check(s0_entity_type_kind(type1) == s0_entity_type_kind(type2));
+    /* Free everything */
+    s0_entity_type_free(type1);
+    s0_entity_type_free(type2);
+}
+
+TEST_CASE("⋄ ∉ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = ⋄ */
+    check_alloc(entity, s0_atom_new());
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("literal ∉ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = literal */
+    check_alloc(entity, s0_literal_new_str("hello"));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_name  *self_name;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = method */
+    check_alloc(self_name, s0_name_new_str("self"));
+    check_alloc(block, create_empty_block());
+    check_alloc(entity, s0_method_new(self_name, block));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("object ∉ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = object */
+    check_alloc(entity, s0_object_new());
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨⤿ ⦃a:*⦄ ...⟩ ∈ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_environment  *env;
+    struct s0_named_blocks  *blocks;
+    struct s0_name_mapping  *inputs;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = ⟨⤿ ⦃a:*⦄ ...⟩ */
+    check_alloc(env, s0_environment_new());
+    check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(inputs, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(inputs, from, to, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(invocation, s0_invoke_closure_new(src, branch));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_named_blocks_add(blocks, name, block));
+    check_alloc(entity, s0_closure_new(env, blocks));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("type of ⟨⤿ ⦃a:*⦄ ...⟩ = ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *type;
+    struct s0_environment  *env;
+    struct s0_named_blocks  *blocks;
+    struct s0_name_mapping  *inputs;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    struct s0_entity_type  *calculated_type;
+    /* type = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(type, s0_closure_entity_type_new(branches));
+    /* entity = ⟨⤿ ⦃a:*⦄ ...⟩ */
+    check_alloc(env, s0_environment_new());
+    check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(inputs, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_name_mapping_add(inputs, from, to, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(invocation, s0_invoke_closure_new(src, branch));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_named_blocks_add(blocks, name, block));
+    check_alloc(entity, s0_closure_new(env, blocks));
+    /* Verify type(entity) = type */
+    check_alloc(calculated_type,
+                s0_closure_entity_type_new_from_closure(entity));
+    check(s0_entity_type_satisfied_by_type(type, calculated_type));
+    check(s0_entity_type_satisfied_by_type(calculated_type, type));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+    s0_entity_type_free(calculated_type);
+}
+
+/*-----------------------------------------------------------------------------
+ * S₀: Entity types: Subtyping
+ */
+
+TEST_CASE_GROUP("S₀ entity types: subtyping");
 
 TEST_CASE("* ⊆ *") {
     struct s0_entity_type  *requires;
     struct s0_entity_type  *have;
+    /* requires = * */
     check_alloc(requires, s0_any_entity_type_new());
+    /* have = * */
     check_alloc(have, s0_any_entity_type_new());
+    /* Verify have ⊆ requires */
     check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⤿ ⦃a:*⦄ ⊆ *") {
+    struct s0_entity_type  *requires;
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *have;
+    /* requires = * */
+    check_alloc(requires, s0_any_entity_type_new());
+    /* have = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(have, s0_closure_entity_type_new(branches));
+    /* Verify have ⊆ requires */
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("* ⊈ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(requires, s0_closure_entity_type_new(branches));
+    /* have = * */
+    check_alloc(have, s0_any_entity_type_new());
+    /* Verify have ⊈ requires */
+    check(!s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⤿ ⦃a:*⦄ ⊆ ⤿ ⦃a:*⦄") {
+    struct s0_environment_type_mapping  *branches;
+    struct s0_environment_type  *branch_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = * */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(requires, s0_closure_entity_type_new(branches));
+    /* have = ⤿ ⦃a:*⦄ */
+    check_alloc(branches, s0_environment_type_mapping_new());
+    check_alloc(branch_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(branch_type, name, input_type));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_environment_type_mapping_add(branches, name, branch_type));
+    check_alloc(have, s0_closure_entity_type_new(branches));
+    /* Verify have ⊆ requires */
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
     s0_entity_type_free(requires);
     s0_entity_type_free(have);
 }

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -2010,22 +2010,24 @@ TEST_CASE("can add `create-method` to environment type") {
 
 TEST_CASE("can add `invoke-closure` to environment type") {
     struct s0_environment_type  *type;
-    struct s0_name  *name;
-    struct s0_entity_type  *etype;
     struct s0_name  *src;
     struct s0_name  *branch;
     struct s0_invocation  *invocation;
-    check_alloc(type, s0_environment_type_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check_alloc(etype, s0_any_entity_type_new());
-    check0(s0_environment_type_add(type, name, etype));
+    /* initial env = ⦃a:⤿ ⦃b:*⦄, b:*⦄ */
+    check_alloc(type, environment_type(
+                YAML
+                "a: !s0!closure\n"
+                "  branches:\n"
+                "    cont:\n"
+                "      b: !s0!any {}\n"
+                "b: !s0!any {}\n"
+                ));
+    /* Then add the invocation */
     check_alloc(src, s0_name_new_str("a"));
-    check_alloc(branch, s0_name_new_str("body"));
+    check_alloc(branch, s0_name_new_str("cont"));
     check_alloc(invocation, s0_invoke_closure_new(src, branch));
     check0(s0_environment_type_add_invocation(type, invocation));
-    check_alloc(name, s0_name_new_str("a"));
-    check(s0_environment_type_get(type, name) == NULL);
-    s0_name_free(name);
+    /* Free everything */
     s0_invocation_free(invocation);
     s0_environment_type_free(type);
 }

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1862,17 +1862,24 @@ TEST_CASE("can add `create-atom` to environment type") {
     struct s0_name  *dest;
     struct s0_statement  *stmt;
     struct s0_name  *name;
-    struct s0_entity_type  *etype;
+    struct s0_entity_type  *actual;
+    struct s0_entity_type  *expected;
+    /* Create environment from statement */
     check_alloc(type, s0_environment_type_new());
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(stmt, s0_create_atom_new(dest));
     check0(s0_environment_type_add_statement(type, stmt));
+    /* expected = * */
+    check_alloc(expected, s0_any_entity_type_new());
+    /* Verify actual == expected */
     check_alloc(name, s0_name_new_str("a"));
-    check_nonnull(etype = s0_environment_type_get(type, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    check_nonnull(actual = s0_environment_type_get(type, name));
+    check(s0_entity_type_equiv(actual, expected));
     s0_name_free(name);
+    /* Free everything */
     s0_statement_free(stmt);
     s0_environment_type_free(type);
+    s0_entity_type_free(expected);
 }
 
 TEST_CASE("can add `create-closure` to environment type") {
@@ -1882,19 +1889,28 @@ TEST_CASE("can add `create-closure` to environment type") {
     struct s0_named_blocks  *branches;
     struct s0_statement  *stmt;
     struct s0_name  *name;
-    struct s0_entity_type  *etype;
+    struct s0_entity_type  *actual;
+    struct s0_environment_type_mapping  *branch_types;
+    struct s0_entity_type  *expected;
+    /* Create environment from statement */
     check_alloc(type, s0_environment_type_new());
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(closed_over, s0_name_set_new());
     check_alloc(branches, s0_named_blocks_new());
     check_alloc(stmt, s0_create_closure_new(dest, closed_over, branches));
     check0(s0_environment_type_add_statement(type, stmt));
+    /* expected = ⤿ */
+    check_alloc(branch_types, s0_environment_type_mapping_new());
+    check_alloc(expected, s0_closure_entity_type_new(branch_types));
+    /* Verify actual == expected */
     check_alloc(name, s0_name_new_str("a"));
-    check_nonnull(etype = s0_environment_type_get(type, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    check_nonnull(actual = s0_environment_type_get(type, name));
+    check(s0_entity_type_equiv(actual, expected));
     s0_name_free(name);
+    /* Free everything */
     s0_statement_free(stmt);
     s0_environment_type_free(type);
+    s0_entity_type_free(expected);
 }
 
 TEST_CASE("can add `create-literal` to environment type") {
@@ -1902,17 +1918,24 @@ TEST_CASE("can add `create-literal` to environment type") {
     struct s0_name  *dest;
     struct s0_statement  *stmt;
     struct s0_name  *name;
-    struct s0_entity_type  *etype;
+    struct s0_entity_type  *actual;
+    struct s0_entity_type  *expected;
+    /* Create environment from statement */
     check_alloc(type, s0_environment_type_new());
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(stmt, s0_create_literal_new(dest, 5, "hello"));
     check0(s0_environment_type_add_statement(type, stmt));
+    /* expected = * */
+    check_alloc(expected, s0_any_entity_type_new());
+    /* Verify actual == expected */
     check_alloc(name, s0_name_new_str("a"));
-    check_nonnull(etype = s0_environment_type_get(type, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    check_nonnull(actual = s0_environment_type_get(type, name));
+    check(s0_entity_type_equiv(actual, expected));
     s0_name_free(name);
+    /* Free everything */
     s0_statement_free(stmt);
     s0_environment_type_free(type);
+    s0_entity_type_free(expected);
 }
 
 TEST_CASE("can add `create-method` to environment type") {
@@ -1922,19 +1945,26 @@ TEST_CASE("can add `create-method` to environment type") {
     struct s0_block  *body;
     struct s0_statement  *stmt;
     struct s0_name  *name;
-    struct s0_entity_type  *etype;
+    struct s0_entity_type  *actual;
+    struct s0_entity_type  *expected;
+    /* Create environment from statement */
     check_alloc(type, s0_environment_type_new());
     check_alloc(dest, s0_name_new_str("a"));
     check_alloc(self_input, s0_name_new_str("self"));
     check_alloc(body, create_empty_block());
     check_alloc(stmt, s0_create_method_new(dest, self_input, body));
     check0(s0_environment_type_add_statement(type, stmt));
+    /* expected = * */
+    check_alloc(expected, s0_any_entity_type_new());
+    /* Verify actual == expected */
     check_alloc(name, s0_name_new_str("a"));
-    check_nonnull(etype = s0_environment_type_get(type, name));
-    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    check_nonnull(actual = s0_environment_type_get(type, name));
+    check(s0_entity_type_equiv(actual, expected));
     s0_name_free(name);
+    /* Free everything */
     s0_statement_free(stmt);
     s0_environment_type_free(type);
+    s0_entity_type_free(expected);
 }
 
 TEST_CASE("can add `invoke-closure` to environment type") {

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1162,6 +1162,40 @@ TEST_CASE("can check which names belong to environment type") {
     s0_environment_type_free(type);
 }
 
+TEST_CASE("can copy environment type") {
+    struct s0_environment_type  *type;
+    struct s0_environment_type  *type_copy;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+
+    /* Construct {a: any, b: any} and then make a copy of it. */
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(type_copy, s0_environment_type_new_copy(type));
+    s0_environment_type_free(type);
+
+    check_alloc(name, s0_name_new_str("a"));
+    check_nonnull(etype = s0_environment_type_get(type_copy, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("b"));
+    check_nonnull(etype = s0_environment_type_get(type_copy, name));
+    check(s0_entity_type_kind(etype) == S0_ENTITY_TYPE_KIND_ANY);
+    s0_name_free(name);
+
+    check_alloc(name, s0_name_new_str("c"));
+    check(s0_environment_type_get(type_copy, name) == NULL);
+    s0_name_free(name);
+
+    s0_environment_type_free(type_copy);
+}
+
 TEST_CASE("can iterate through names in type") {
     struct s0_environment_type  *type;
     struct s0_environment_type_entry  entry;

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1482,6 +1482,50 @@ TEST_CASE("can add `create-method` to environment type") {
     s0_environment_type_free(type);
 }
 
+TEST_CASE("can add `invoke-closure` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_invocation  *invocation;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("body"));
+    check_alloc(invocation, s0_invoke_closure_new(src, branch));
+    check0(s0_environment_type_add_invocation(type, invocation));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_get(type, name) == NULL);
+    s0_name_free(name);
+    s0_invocation_free(invocation);
+    s0_environment_type_free(type);
+}
+
+TEST_CASE("can add `invoke-method` to environment type") {
+    struct s0_environment_type  *type;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    struct s0_name  *src;
+    struct s0_name  *method;
+    struct s0_invocation  *invocation;
+    check_alloc(type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(type, name, etype));
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(method, s0_name_new_str("run"));
+    check_alloc(invocation, s0_invoke_method_new(src, method));
+    check0(s0_environment_type_add_invocation(type, invocation));
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_get(type, name) == NULL);
+    s0_name_free(name);
+    s0_invocation_free(invocation);
+    s0_environment_type_free(type);
+}
+
 TEST_CASE("can create external environment type from input mappings") {
     struct s0_name_mapping  *mapping;
     struct s0_name  *from;

--- a/tests/s0/parsing/create-atom.yaml
+++ b/tests/s0/parsing/create-atom.yaml
@@ -3,7 +3,8 @@
 !s0!successful-parse
 name: create-atom can create a new environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-atom
       dest: x
@@ -17,7 +18,8 @@ module:
 !s0!invalid-parse
 name: create-atom needs a destination
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-atom {}
   invocation:
@@ -32,6 +34,7 @@ name: create-atom cannot overwrite an input
 module:
   inputs:
     x: x
+    exit: exit
   statements:
     - !s0!create-atom
       dest: x
@@ -45,7 +48,8 @@ module:
 !s0!invalid-parse
 name: create-atom cannot overwrite an existing environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-atom
       dest: x

--- a/tests/s0/parsing/create-atom.yaml
+++ b/tests/s0/parsing/create-atom.yaml
@@ -4,14 +4,16 @@
 name: create-atom can create a new environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -19,13 +21,15 @@ module:
 name: create-atom needs a destination
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-atom {}
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -33,15 +37,19 @@ module:
 name: create-atom cannot overwrite an input
 module:
   inputs:
-    x: x
-    exit: exit
+    - external: x
+      internal: x
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -49,7 +57,9 @@ module:
 name: create-atom cannot overwrite an existing environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -58,4 +68,4 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return

--- a/tests/s0/parsing/create-atom.yaml
+++ b/tests/s0/parsing/create-atom.yaml
@@ -6,7 +6,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -23,7 +26,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-atom {}
   invocation:
@@ -42,7 +48,10 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -59,7 +68,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -3,14 +3,16 @@
 !s0!successful-parse
 name: create-closure can create a new environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
       closed-over: []
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -26,13 +28,15 @@ module:
 !s0!invalid-parse
 name: create-closure needs a destination
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       closed-over: []
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -48,13 +52,15 @@ module:
 !s0!invalid-parse
 name: create-closure needs a closure set
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -70,7 +76,8 @@ module:
 !s0!invalid-parse
 name: create-closure needs a branches section
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
@@ -85,7 +92,8 @@ module:
 !s0!invalid-parse
 name: create-closure needs at least one branch
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
@@ -103,13 +111,15 @@ name: create-closure cannot overwrite an input
 module:
   inputs:
     x: x
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
       closed-over: []
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -125,14 +135,16 @@ module:
 !s0!invalid-parse
 name: create-closure cannot overwrite an existing environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
       closed-over: []
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -143,7 +155,8 @@ module:
       closed-over: []
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -159,7 +172,8 @@ module:
 !s0!invalid-parse
 name: create-closure closure set cannot contain duplicates
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
@@ -168,7 +182,8 @@ module:
         - x
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
@@ -184,7 +199,8 @@ module:
 !s0!invalid-parse
 name: create-closure branch list cannot contain duplicates
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-closure
       dest: x
@@ -192,14 +208,16 @@ module:
         - x
       branches:
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: call
         body:
-          inputs: {}
+          inputs:
+            exit: exit
           statements: []
           invocation:
             !s0!invoke-closure

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -6,7 +6,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -16,7 +19,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -35,7 +40,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       closed-over: []
@@ -44,7 +52,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -63,7 +73,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -72,7 +85,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -91,7 +106,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -109,7 +127,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -131,7 +152,10 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -141,7 +165,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -160,7 +186,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -170,7 +199,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -184,7 +215,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -203,7 +236,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -215,7 +251,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -234,7 +272,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -245,7 +286,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure
@@ -255,7 +298,9 @@ module:
           inputs:
             - external: exit
               internal: exit
-              type: !s0!any {}
+              type: !s0!closure
+                branches:
+                  return: {}
           statements: []
           invocation:
             !s0!invoke-closure

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -4,7 +4,9 @@
 name: create-closure can create a new environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -12,16 +14,18 @@ module:
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -29,23 +33,27 @@ module:
 name: create-closure needs a destination
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       closed-over: []
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -53,23 +61,27 @@ module:
 name: create-closure needs a closure set
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -77,7 +89,9 @@ module:
 name: create-closure needs a branches section
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -85,7 +99,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -93,7 +107,9 @@ module:
 name: create-closure needs at least one branch
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -102,7 +118,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -110,8 +126,12 @@ module:
 name: create-closure cannot overwrite an input
 module:
   inputs:
-    x: x
-    exit: exit
+    - external: x
+      internal: x
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -119,16 +139,18 @@ module:
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -136,7 +158,9 @@ module:
 name: create-closure cannot overwrite an existing environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -144,28 +168,32 @@ module:
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
     - !s0!create-closure
       dest: x
       closed-over: []
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -173,7 +201,9 @@ module:
 name: create-closure closure set cannot contain duplicates
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -183,16 +213,18 @@ module:
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -200,7 +232,9 @@ module:
 name: create-closure branch list cannot contain duplicates
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -209,21 +243,25 @@ module:
       branches:
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
         body:
           inputs:
-            exit: exit
+            - external: exit
+              internal: exit
+              type: !s0!any {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
-            branch: call
+            branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return

--- a/tests/s0/parsing/create-literal.yaml
+++ b/tests/s0/parsing/create-literal.yaml
@@ -3,7 +3,8 @@
 !s0!successful-parse
 name: create-literal can create a new environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -18,7 +19,8 @@ module:
 !s0!successful-parse
 name: create-literal content can be a number
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -33,7 +35,8 @@ module:
 !s0!successful-parse
 name: create-literal content can include spaces
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -48,7 +51,8 @@ module:
 !s0!successful-parse
 name: create-literal content can include any kind of punctuation
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -64,7 +68,8 @@ module:
 !s0!successful-parse
 name: create-literal content can include Unicode control characters
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -80,7 +85,8 @@ module:
 !s0!invalid-parse
 name: create-literal needs a destination
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       content: stuff
@@ -94,7 +100,8 @@ module:
 !s0!invalid-parse
 name: create-literal needs content
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -108,7 +115,8 @@ module:
 !s0!invalid-parse
 name: create-literal content cannot be a sequence
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -123,7 +131,8 @@ module:
 !s0!invalid-parse
 name: create-literal content cannot be a mapping
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -140,6 +149,7 @@ name: create-literal cannot overwrite an input
 module:
   inputs:
     x: x
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x
@@ -154,7 +164,8 @@ module:
 !s0!invalid-parse
 name: create-literal cannot overwrite an existing environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-literal
       dest: x

--- a/tests/s0/parsing/create-literal.yaml
+++ b/tests/s0/parsing/create-literal.yaml
@@ -6,7 +6,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -24,7 +27,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -42,7 +48,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -60,7 +69,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -79,7 +91,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -98,7 +113,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       content: stuff
@@ -115,7 +133,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -132,7 +153,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -150,7 +174,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -171,7 +198,10 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -189,7 +219,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x

--- a/tests/s0/parsing/create-literal.yaml
+++ b/tests/s0/parsing/create-literal.yaml
@@ -4,7 +4,9 @@
 name: create-literal can create a new environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -12,7 +14,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -20,7 +22,9 @@ module:
 name: create-literal content can be a number
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -28,7 +32,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -36,7 +40,9 @@ module:
 name: create-literal content can include spaces
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -44,7 +50,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -52,7 +58,9 @@ module:
 name: create-literal content can include any kind of punctuation
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -61,7 +69,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -69,7 +77,9 @@ module:
 name: create-literal content can include Unicode control characters
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -78,7 +88,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -86,14 +96,16 @@ module:
 name: create-literal needs a destination
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       content: stuff
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -101,14 +113,16 @@ module:
 name: create-literal needs content
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -116,7 +130,9 @@ module:
 name: create-literal content cannot be a sequence
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -124,7 +140,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -132,7 +148,9 @@ module:
 name: create-literal content cannot be a mapping
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -140,7 +158,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -148,8 +166,12 @@ module:
 name: create-literal cannot overwrite an input
 module:
   inputs:
-    x: x
-    exit: exit
+    - external: x
+      internal: x
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -157,7 +179,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -165,7 +187,9 @@ module:
 name: create-literal cannot overwrite an existing environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -176,4 +200,4 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -4,23 +4,27 @@
 name: create-method can create a new environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          exit: exit
+          - external: exit
+            internal: exit
+            type: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -28,7 +32,9 @@ module:
 name: create-method needs a destination
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       self-input: self
@@ -39,11 +45,11 @@ module:
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -51,22 +57,26 @@ module:
 name: create-method needs a self input
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       body:
         inputs:
-          exit: exit
+          - external: exit
+            internal: exit
+            type: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -74,7 +84,9 @@ module:
 name: create-method needs a body
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -82,7 +94,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -90,24 +102,30 @@ module:
 name: create-method cannot overwrite an input
 module:
   inputs:
-    x: x
-    exit: exit
+    - external: x
+      internal: x
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          exit: exit
+          - external: exit
+            internal: exit
+            type: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -115,31 +133,37 @@ module:
 name: create-method cannot overwrite an existing environment entry
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          exit: exit
+          - external: exit
+            internal: exit
+            type: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          exit: exit
+          - external: exit
+            internal: exit
+            type: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
-          branch: call
+          branch: return
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -3,13 +3,15 @@
 !s0!successful-parse
 name: create-method can create a new environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure
@@ -25,12 +27,14 @@ module:
 !s0!invalid-parse
 name: create-method needs a destination
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-method
       self-input: self
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure
@@ -46,12 +50,14 @@ module:
 !s0!invalid-parse
 name: create-method needs a self input
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-method
       dest: x
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure
@@ -67,7 +73,8 @@ module:
 !s0!invalid-parse
 name: create-method needs a body
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-method
       dest: x
@@ -84,12 +91,14 @@ name: create-method cannot overwrite an input
 module:
   inputs:
     x: x
+    exit: exit
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure
@@ -105,13 +114,15 @@ module:
 !s0!invalid-parse
 name: create-method cannot overwrite an existing environment entry
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure
@@ -121,7 +132,8 @@ module:
       dest: x
       self-input: self
       body:
-        inputs: {}
+        inputs:
+          exit: exit
         statements: []
         invocation:
           !s0!invoke-closure

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -6,7 +6,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -15,7 +18,9 @@ module:
         inputs:
           - external: exit
             internal: exit
-            type: !s0!any {}
+            type: !s0!closure
+              branches:
+                return: {}
         statements: []
         invocation:
           !s0!invoke-closure
@@ -34,7 +39,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       self-input: self
@@ -59,7 +67,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -67,7 +78,9 @@ module:
         inputs:
           - external: exit
             internal: exit
-            type: !s0!any {}
+            type: !s0!closure
+              branches:
+                return: {}
         statements: []
         invocation:
           !s0!invoke-closure
@@ -86,7 +99,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -107,7 +123,10 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -116,7 +135,9 @@ module:
         inputs:
           - external: exit
             internal: exit
-            type: !s0!any {}
+            type: !s0!closure
+              branches:
+                return: {}
         statements: []
         invocation:
           !s0!invoke-closure
@@ -135,7 +156,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -144,7 +168,9 @@ module:
         inputs:
           - external: exit
             internal: exit
-            type: !s0!any {}
+            type: !s0!closure
+              branches:
+                return: {}
         statements: []
         invocation:
           !s0!invoke-closure
@@ -157,7 +183,9 @@ module:
         inputs:
           - external: exit
             internal: exit
-            type: !s0!any {}
+            type: !s0!closure
+              branches:
+                return: {}
         statements: []
         invocation:
           !s0!invoke-closure

--- a/tests/s0/parsing/inputs.yaml
+++ b/tests/s0/parsing/inputs.yaml
@@ -1,29 +1,20 @@
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!successful-parse
-name: The input set can be empty
-module:
-  inputs:
-    exit: exit
-  statements: []
-  invocation:
-    !s0!invoke-closure
-    src: exit
-    branch: call
-
-%TAG !s0! tag:swanson-lang.org,2016:
----
-!s0!successful-parse
 name: The name of an input doesn't need to change
 module:
   inputs:
-    self: self
-    exit: exit
+    - external: self
+      internal: self
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -31,14 +22,20 @@ module:
 name: All of the renamings happen "at the same time"
 module:
   inputs:
-    a: b
-    b: a
-    exit: exit
+    - external: a
+      internal: b
+      type: !s0!any {}
+    - external: b
+      internal: a
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -46,14 +43,20 @@ module:
 name: There cannot be multiple inputs with the same "from" name
 module:
   inputs:
-    a: b
-    a: c
-    exit: exit
+    - external: a
+      internal: b
+      type: !s0!any {}
+    - external: a
+      internal: c
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 error: >
   There is already an input named `a`.
 
@@ -63,13 +66,19 @@ error: >
 name: There cannot be multiple inputs with the same "to" name
 module:
   inputs:
-    a: c
-    b: c
-    exit: exit
+    - external: a
+      internal: c
+      type: !s0!any {}
+    - external: b
+      internal: c
+      type: !s0!any {}
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 error: >
   There is already an input that is renamed to `c`.

--- a/tests/s0/parsing/inputs.yaml
+++ b/tests/s0/parsing/inputs.yaml
@@ -3,7 +3,8 @@
 !s0!successful-parse
 name: The input set can be empty
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -17,6 +18,7 @@ name: The name of an input doesn't need to change
 module:
   inputs:
     self: self
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -31,6 +33,7 @@ module:
   inputs:
     a: b
     b: a
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -45,6 +48,7 @@ module:
   inputs:
     a: b
     a: c
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -61,6 +65,7 @@ module:
   inputs:
     a: c
     b: c
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure

--- a/tests/s0/parsing/inputs.yaml
+++ b/tests/s0/parsing/inputs.yaml
@@ -4,12 +4,11 @@
 name: The name of an input doesn't need to change
 module:
   inputs:
-    - external: self
-      internal: self
-      type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -30,7 +29,11 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return:
+            a: !s0!any {}
+            b: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -51,7 +54,9 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -74,7 +79,9 @@ module:
       type: !s0!any {}
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -6,7 +6,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -21,7 +23,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -35,7 +39,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          return: {}
   statements: []
   invocation:
     !s0!invoke-closure

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -4,12 +4,14 @@
 name: invoke-closure can call a closure in the environment
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -17,11 +19,13 @@ module:
 name: invoke-closure needs a source
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
-    branch: call
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -29,7 +33,9 @@ module:
 name: invoke-closure needs a branch
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -45,7 +51,7 @@ module:
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: call
+    branch: return
 
 # TODO - invoke-closure cannot call an atom
 # TODO - invoke-closure cannot call a literal

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -16,7 +16,8 @@ module:
 !s0!invalid-parse
 name: invoke-closure needs a source
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -34,7 +35,18 @@ module:
     !s0!invoke-closure
     src: exit
 
-# TODO - invoke-closure cannot call a missing environment entry
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-closure cannot call a missing environment entry
+module:
+  inputs: {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: call
+
 # TODO - invoke-closure cannot call an atom
 # TODO - invoke-closure cannot call a literal
 # TODO - invoke-closure cannot call a method

--- a/tests/s0/parsing/invoke-method.yaml
+++ b/tests/s0/parsing/invoke-method.yaml
@@ -16,7 +16,8 @@ module:
 !s0!invalid-parse
 name: invoke-method needs a source
 module:
-  inputs: {}
+  inputs:
+    self: self
   statements: []
   invocation:
     !s0!invoke-method

--- a/tests/s0/parsing/invoke-method.yaml
+++ b/tests/s0/parsing/invoke-method.yaml
@@ -4,7 +4,9 @@
 name: invoke-method can call a method in the environment
 module:
   inputs:
-    self: self
+    - external: self
+      internal: self
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
@@ -17,7 +19,11 @@ module:
 name: invoke-method needs a source
 module:
   inputs:
-    self: self
+module:
+  inputs:
+    - external: self
+      internal: self
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
@@ -29,7 +35,9 @@ module:
 name: invoke-method needs a method
 module:
   inputs:
-    self: self
+    - external: self
+      internal: self
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method

--- a/tests/s0/parsing/names.yaml
+++ b/tests/s0/parsing/names.yaml
@@ -3,7 +3,8 @@
 !s0!successful-parse
 name: A name can be a number
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -15,7 +16,8 @@ module:
 !s0!successful-parse
 name: A name can include spaces
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -27,7 +29,8 @@ module:
 !s0!successful-parse
 name: A name can include any kind of punctuation
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -40,7 +43,8 @@ module:
 !s0!successful-parse
 name: A name can include Unicode control characters
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -53,7 +57,8 @@ module:
 !s0!invalid-parse
 name: A name cannot be a sequence
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure
@@ -65,7 +70,8 @@ module:
 !s0!invalid-parse
 name: A name cannot be a mapping
 module:
-  inputs: {}
+  inputs:
+    exit: exit
   statements: []
   invocation:
     !s0!invoke-closure

--- a/tests/s0/parsing/names.yaml
+++ b/tests/s0/parsing/names.yaml
@@ -4,7 +4,9 @@
 name: A name can be a number
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -17,7 +19,9 @@ module:
 name: A name can include spaces
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -30,7 +34,9 @@ module:
 name: A name can include any kind of punctuation
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -44,7 +50,9 @@ module:
 name: A name can include Unicode control characters
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -58,7 +66,9 @@ module:
 name: A name cannot be a sequence
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -71,7 +81,9 @@ module:
 name: A name cannot be a mapping
 module:
   inputs:
-    exit: exit
+    - external: exit
+      internal: exit
+      type: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure

--- a/tests/s0/parsing/names.yaml
+++ b/tests/s0/parsing/names.yaml
@@ -6,7 +6,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          1337: {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -21,7 +23,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          "call function": {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -36,7 +40,11 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          ? |
+            call !@#$%^&*()-=_+[]{}|\;':",./<>?`~
+          : {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -52,7 +60,9 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          "call\x1ffunction": {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -68,7 +78,10 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          ? []
+          : {}
   statements: []
   invocation:
     !s0!invoke-closure
@@ -83,9 +96,12 @@ module:
   inputs:
     - external: exit
       internal: exit
-      type: !s0!any {}
+      type: !s0!closure
+        branches:
+          ? {}
+          : {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
-    branch: []
+    branch: {}


### PR DESCRIPTION
We should verify invocations, as well, not just statements.