### PR TITLE
Move renaming to invocations

### DIFF
--- a/tests/s0/parsing/create-atom.yaml
+++ b/tests/s0/parsing/create-atom.yaml
@@ -4,12 +4,10 @@
 name: create-atom can create a new environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -17,6 +15,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -24,18 +24,18 @@ module:
 name: create-atom needs a destination
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-atom {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -43,15 +43,11 @@ module:
 name: create-atom cannot overwrite an input
 module:
   inputs:
-    - external: x
-      internal: x
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -59,6 +55,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -66,12 +64,10 @@ module:
 name: create-atom cannot overwrite an existing environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-atom
       dest: x
@@ -81,3 +77,5 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -4,12 +4,10 @@
 name: create-closure can create a new environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -17,20 +15,21 @@ module:
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -38,32 +37,31 @@ module:
 name: create-closure needs a destination
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       closed-over: []
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -71,32 +69,31 @@ module:
 name: create-closure needs a closure set
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -104,12 +101,10 @@ module:
 name: create-closure needs a branches section
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -118,6 +113,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -125,12 +122,10 @@ module:
 name: create-closure needs at least one branch
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -140,6 +135,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -147,15 +144,11 @@ module:
 name: create-closure cannot overwrite an input
 module:
   inputs:
-    - external: x
-      internal: x
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -163,20 +156,21 @@ module:
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -184,12 +178,10 @@ module:
 name: create-closure cannot overwrite an existing environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -197,36 +189,36 @@ module:
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
     - !s0!create-closure
       dest: x
       closed-over: []
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -234,12 +226,10 @@ module:
 name: create-closure closure set cannot contain duplicates
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -249,20 +239,21 @@ module:
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -270,12 +261,10 @@ module:
 name: create-closure branch list cannot contain duplicates
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-closure
       dest: x
@@ -284,29 +273,29 @@ module:
       branches:
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
         body:
           inputs:
-            - external: exit
-              internal: exit
-              type: !s0!closure
-                branches:
-                  return: {}
+            exit: !s0!closure
+              branches:
+                return: {}
           statements: []
           invocation:
             !s0!invoke-closure
             src: exit
             branch: return
+            parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x

--- a/tests/s0/parsing/create-literal.yaml
+++ b/tests/s0/parsing/create-literal.yaml
@@ -4,12 +4,10 @@
 name: create-literal can create a new environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -18,6 +16,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -25,12 +25,10 @@ module:
 name: create-literal content can be a number
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -39,6 +37,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -46,12 +46,10 @@ module:
 name: create-literal content can include spaces
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -60,6 +58,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -67,12 +67,10 @@ module:
 name: create-literal content can include any kind of punctuation
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -82,6 +80,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -89,12 +89,10 @@ module:
 name: create-literal content can include Unicode control characters
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -104,6 +102,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -111,12 +111,10 @@ module:
 name: create-literal needs a destination
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       content: stuff
@@ -124,6 +122,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -131,12 +131,10 @@ module:
 name: create-literal needs content
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -144,6 +142,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -151,12 +151,10 @@ module:
 name: create-literal content cannot be a sequence
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -165,6 +163,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -172,12 +172,10 @@ module:
 name: create-literal content cannot be a mapping
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -186,6 +184,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -193,15 +193,11 @@ module:
 name: create-literal cannot overwrite an input
 module:
   inputs:
-    - external: x
-      internal: x
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -210,6 +206,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -217,12 +215,10 @@ module:
 name: create-literal cannot overwrite an existing environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-literal
       dest: x
@@ -234,3 +230,5 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -4,32 +4,31 @@
 name: create-method can create a new environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          - external: exit
-            internal: exit
-            type: !s0!closure
-              branches:
-                return: {}
+          exit: !s0!closure
+            branches:
+              return: {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -37,12 +36,10 @@ module:
 name: create-method needs a destination
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       self-input: self
@@ -54,10 +51,13 @@ module:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -65,31 +65,30 @@ module:
 name: create-method needs a self input
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       body:
         inputs:
-          - external: exit
-            internal: exit
-            type: !s0!closure
-              branches:
-                return: {}
+          exit: !s0!closure
+            branches:
+              return: {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -97,12 +96,10 @@ module:
 name: create-method needs a body
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
@@ -111,6 +108,8 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -118,35 +117,32 @@ module:
 name: create-method cannot overwrite an input
 module:
   inputs:
-    - external: x
-      internal: x
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          - external: exit
-            internal: exit
-            type: !s0!closure
-              branches:
-                return: {}
+          exit: !s0!closure
+            branches:
+              return: {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -154,44 +150,42 @@ module:
 name: create-method cannot overwrite an existing environment entry
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements:
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          - external: exit
-            internal: exit
-            type: !s0!closure
-              branches:
-                return: {}
+          exit: !s0!closure
+            branches:
+              return: {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
     - !s0!create-method
       dest: x
       self-input: self
       body:
         inputs:
-          - external: exit
-            internal: exit
-            type: !s0!closure
-              branches:
-                return: {}
+          exit: !s0!closure
+            branches:
+              return: {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
+          parameters: {}
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters:
+      x: x

--- a/tests/s0/parsing/inputs.yaml
+++ b/tests/s0/parsing/inputs.yaml
@@ -1,91 +1,22 @@
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
-!s0!successful-parse
-name: The name of an input doesn't need to change
-module:
-  inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
-  statements: []
-  invocation:
-    !s0!invoke-closure
-    src: exit
-    branch: return
-
-%TAG !s0! tag:swanson-lang.org,2016:
----
-!s0!successful-parse
-name: All of the renamings happen "at the same time"
-module:
-  inputs:
-    - external: a
-      internal: b
-      type: !s0!any {}
-    - external: b
-      internal: a
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return:
-            a: !s0!any {}
-            b: !s0!any {}
-  statements: []
-  invocation:
-    !s0!invoke-closure
-    src: exit
-    branch: return
-
-%TAG !s0! tag:swanson-lang.org,2016:
----
 !s0!invalid-parse
-name: There cannot be multiple inputs with the same "from" name
+name: There cannot be multiple inputs with the same name
 module:
   inputs:
-    - external: a
-      internal: b
-      type: !s0!any {}
-    - external: a
-      internal: c
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    params: {}
 error: >
-  There is already an input named `a`.
-
-%TAG !s0! tag:swanson-lang.org,2016:
----
-!s0!invalid-parse
-name: There cannot be multiple inputs with the same "to" name
-module:
-  inputs:
-    - external: a
-      internal: c
-      type: !s0!any {}
-    - external: b
-      internal: c
-      type: !s0!any {}
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
-  statements: []
-  invocation:
-    !s0!invoke-closure
-    src: exit
-    branch: return
-error: >
-  There is already an input that is renamed to `c`.
+  There is already an input names `exit`.

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -4,16 +4,15 @@
 name: invoke-closure can call a closure in the environment
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
+    exit: !s0!closure
+      branches:
+        return: {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -21,15 +20,14 @@ module:
 name: invoke-closure needs a source
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
+    exit: !s0!closure
+      branches:
+        return: {}
   statements: []
   invocation:
     !s0!invoke-closure
     branch: return
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -37,15 +35,29 @@ module:
 name: invoke-closure needs a branch
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          return: {}
+    exit: !s0!closure
+      branches:
+        return: {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
+    parameters: {}
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-closure needs a parameters
+module:
+  inputs:
+    exit: !s0!closure
+      branches:
+        return: {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -58,6 +70,109 @@ module:
     !s0!invoke-closure
     src: exit
     branch: return
+    parameters: {}
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: The name of a parameter can change
+module:
+  inputs:
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      x: y
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: The name of a parameter doesn't need to change
+module:
+  inputs:
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      x: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: All of the renamings happen "at the same time"
+module:
+  inputs:
+    x: !s0!any {}
+    y: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      x: y
+      y: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple parameters with the same "from" name
+module:
+  inputs:
+    x: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      x: x
+      x: y
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple parameters with the same "to" name
+module:
+  inputs:
+    x: !s0!any {}
+    y: !s0!any {}
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      x: x
+      x: x
 
 # TODO - invoke-closure cannot call an atom
 # TODO - invoke-closure cannot call a literal

--- a/tests/s0/parsing/invoke-method.yaml
+++ b/tests/s0/parsing/invoke-method.yaml
@@ -4,14 +4,13 @@
 name: invoke-method can call a method in the environment
 module:
   inputs:
-    - external: self
-      internal: self
-      type: !s0!any {}
+    self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     src: self
     method: id
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -21,13 +20,12 @@ module:
   inputs:
 module:
   inputs:
-    - external: self
-      internal: self
-      type: !s0!any {}
+    self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     method: id
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -35,13 +33,25 @@ module:
 name: invoke-method needs a method
 module:
   inputs:
-    - external: self
-      internal: self
-      type: !s0!any {}
+    self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     src: self
+    parameters: {}
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method needs a param
+module:
+  inputs:
+    self: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
 
 # TODO - invoke-method cannot call a missing environment entry
 # TODO - invoke-method cannot call an atom

--- a/tests/s0/parsing/names.yaml
+++ b/tests/s0/parsing/names.yaml
@@ -4,16 +4,15 @@
 name: A name can be a number
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          1337: {}
+    exit: !s0!closure
+      branches:
+        1337: {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: 1337
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -21,16 +20,15 @@ module:
 name: A name can include spaces
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          "call function": {}
+    exit: !s0!closure
+      branches:
+        "call function": {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: "call function"
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -38,19 +36,18 @@ module:
 name: A name can include any kind of punctuation
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          ? |
-            call !@#$%^&*()-=_+[]{}|\;':",./<>?`~
-          : {}
+    exit: !s0!closure
+      branches:
+        ? |
+          call !@#$%^&*()-=_+[]{}|\;':",./<>?`~
+        : {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: |
       call !@#$%^&*()-=_+[]{}|\;':",./<>?`~
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -58,17 +55,16 @@ module:
 name: A name can include Unicode control characters
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          "call\x1ffunction": {}
+    exit: !s0!closure
+      branches:
+        "call\x1ffunction": {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     # \x1f is "Unit Separator"
     branch: "call\x1ffunction"
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -76,17 +72,16 @@ module:
 name: A name cannot be a sequence
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          ? []
-          : {}
+    exit: !s0!closure
+      branches:
+        ? []
+        : {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: []
+    parameters: {}
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -94,14 +89,13 @@ module:
 name: A name cannot be a mapping
 module:
   inputs:
-    - external: exit
-      internal: exit
-      type: !s0!closure
-        branches:
-          ? {}
-          : {}
+    exit: !s0!closure
+      branches:
+        ? {}
+        : {}
   statements: []
   invocation:
     !s0!invoke-closure
     src: exit
     branch: {}
+    parameters: {}


### PR DESCRIPTION
Before, you could apply a "renaming" to the inputs of a block, so that the caller of the block could provide one set of names, but the inside of the block would those values at a different set of names.  We've moved things around so that this renaming is now defined when you *invoke* the block (via `invoke-closure` or `invoke-method`), instead of when you *define* the block.