### PR TITLE
Remove `self_input` from methods

### DIFF
--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -244,18 +244,13 @@ size_t
 s0_create_literal_size(const struct s0_statement *);
 
 
-/* Takes control of dest, self_input, and body */
+/* Takes control of dest and body */
 struct s0_statement *
-s0_create_method_new(struct s0_name *dest, struct s0_name *self_input,
-                     struct s0_block *body);
+s0_create_method_new(struct s0_name *dest, struct s0_block *body);
 
 /* Statement MUST be CreateMethod */
 struct s0_name *
 s0_create_method_dest(const struct s0_statement *);
-
-/* Statement MUST be CreateMethod */
-struct s0_name *
-s0_create_method_self_input(const struct s0_statement *);
 
 /* Statement MUST be CreateMethod */
 struct s0_block *
@@ -424,13 +419,9 @@ size_t
 s0_literal_size(const struct s0_entity *);
 
 
-/* Takes control of self_name and block */
+/* Takes control block */
 struct s0_entity *
-s0_method_new(struct s0_name *self_name, struct s0_block *block);
-
-/* Entity MUST be a method.  method retains ownership of self_name. */
-struct s0_name *
-s0_method_self_name(const struct s0_entity *);
+s0_method_new(struct s0_block *block);
 
 /* Entity MUST be a method.  method retains ownership of block. */
 struct s0_block *

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -79,7 +79,6 @@ struct s0_statement {
         } create_literal;
         struct {
             struct s0_name  *dest;
-            struct s0_name  *self_input;
             struct s0_block  *body;
         } create_method;
     } _;
@@ -119,7 +118,6 @@ struct s0_entity {
             const void  *content;
         } literal;
         struct {
-            struct s0_name  *self_name;
             struct s0_block  *block;
         } method;
         struct {
@@ -782,19 +780,16 @@ s0_create_literal_size(const struct s0_statement *stmt)
 
 
 struct s0_statement *
-s0_create_method_new(struct s0_name *dest, struct s0_name *self_input,
-                     struct s0_block *body)
+s0_create_method_new(struct s0_name *dest, struct s0_block *body)
 {
     struct s0_statement  *stmt = malloc(sizeof(struct s0_statement));
     if (unlikely(stmt == NULL)) {
         s0_name_free(dest);
-        s0_name_free(self_input);
         s0_block_free(body);
         return NULL;
     }
     stmt->type = S0_STATEMENT_KIND_CREATE_METHOD;
     stmt->_.create_method.dest = dest;
-    stmt->_.create_method.self_input = self_input;
     stmt->_.create_method.body = body;
     return stmt;
 }
@@ -803,7 +798,6 @@ static void
 s0_create_method_free(struct s0_statement *stmt)
 {
     s0_name_free(stmt->_.create_method.dest);
-    s0_name_free(stmt->_.create_method.self_input);
     s0_block_free(stmt->_.create_method.body);
 }
 
@@ -812,13 +806,6 @@ s0_create_method_dest(const struct s0_statement *stmt)
 {
     assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.dest;
-}
-
-struct s0_name *
-s0_create_method_self_input(const struct s0_statement *stmt)
-{
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
-    return stmt->_.create_method.self_input;
 }
 
 struct s0_block *
@@ -1165,16 +1152,14 @@ s0_literal_size(const struct s0_entity *literal)
 
 
 struct s0_entity *
-s0_method_new(struct s0_name *self_name, struct s0_block *block)
+s0_method_new(struct s0_block *block)
 {
     struct s0_entity  *method = malloc(sizeof(struct s0_entity));
     if (unlikely(method == NULL)) {
-        s0_name_free(self_name);
         s0_block_free(block);
         return NULL;
     }
     method->type = S0_ENTITY_KIND_METHOD;
-    method->_.method.self_name = self_name;
     method->_.method.block = block;
     return method;
 }
@@ -1182,15 +1167,7 @@ s0_method_new(struct s0_name *self_name, struct s0_block *block)
 static void
 s0_method_free(struct s0_entity *method)
 {
-    s0_name_free(method->_.method.self_name);
     s0_block_free(method->_.method.block);
-}
-
-struct s0_name *
-s0_method_self_name(const struct s0_entity *method)
-{
-    assert(method->type == S0_ENTITY_KIND_METHOD);
-    return method->_.method.self_name;
 }
 
 struct s0_block *

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -752,7 +752,6 @@ s0_load_create_method(struct s0_yaml_node node)
     /* We've already verified that this is a !s0!create-method mapping node. */
     struct s0_yaml_node  item;
     struct s0_name  *dest;
-    struct s0_name  *self_input;
     struct s0_block  *body;
 
     /* dest */
@@ -770,24 +769,6 @@ s0_load_create_method(struct s0_yaml_node node)
         return NULL;
     }
 
-    /* self_input */
-
-    item = s0_yaml_node_mapping_get(node, "self-input");
-    if (unlikely(s0_yaml_node_is_missing(item))) {
-        fill_error(node.stream,
-                   "create-method requires a self-input at %zu:%zu",
-                   s0_yaml_node_get_node(node)->start_mark.line,
-                   s0_yaml_node_get_node(node)->start_mark.column);
-        s0_name_free(dest);
-        return NULL;
-    }
-
-    self_input = s0_load_name(item);
-    if (unlikely(self_input == NULL)) {
-        s0_name_free(dest);
-        return NULL;
-    }
-
     /* body */
 
     item = s0_yaml_node_mapping_get(node, "body");
@@ -796,18 +777,16 @@ s0_load_create_method(struct s0_yaml_node node)
                    s0_yaml_node_get_node(node)->start_mark.line,
                    s0_yaml_node_get_node(node)->start_mark.column);
         s0_name_free(dest);
-        s0_name_free(self_input);
         return NULL;
     }
 
     body = s0_load_block(item);
     if (unlikely(body == NULL)) {
         s0_name_free(dest);
-        s0_name_free(self_input);
         return NULL;
     }
 
-    return s0_create_method_new(dest, self_input, body);
+    return s0_create_method_new(dest, body);
 }
 
 static struct s0_statement *

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -521,23 +521,17 @@ TEST_CASE("can create `create-literal` statement") {
 
 TEST_CASE("can create `create-method` statement") {
     struct s0_name  *dest;
-    struct s0_name  *self_input;
     struct s0_block  *body;
     struct s0_statement  *stmt;
 
     check_alloc(dest, s0_name_new_str("a"));
-    check_alloc(self_input, s0_name_new_str("self"));
     check_alloc(body, create_empty_block());
-    check_alloc(stmt, s0_create_method_new(dest, self_input, body));
+    check_alloc(stmt, s0_create_method_new(dest, body));
     check(s0_statement_kind(stmt) == S0_STATEMENT_KIND_CREATE_METHOD);
 
     check_alloc(dest, s0_name_new_str("a"));
     check(s0_name_eq(s0_create_method_dest(stmt), dest));
     s0_name_free(dest);
-
-    check_alloc(self_input, s0_name_new_str("self"));
-    check(s0_name_eq(s0_create_method_self_input(stmt), self_input));
-    s0_name_free(self_input);
 
     check(s0_create_method_body(stmt) == body);
 
@@ -798,15 +792,10 @@ TEST_CASE_GROUP("S₀ methods");
 
 TEST_CASE("can create method") {
     struct s0_entity  *method;
-    struct s0_name  *self_name;
     struct s0_block  *block;
-    check_alloc(self_name, s0_name_new_str("self"));
     check_alloc(block, create_empty_block());
-    check_alloc(method, s0_method_new(self_name, block));
+    check_alloc(method, s0_method_new(block));
     check(s0_entity_kind(method) == S0_ENTITY_KIND_METHOD);
-    check_alloc(self_name, s0_name_new_str("self"));
-    check(s0_name_eq(s0_method_self_name(method), self_name));
-    s0_name_free(self_name);
     check(s0_method_block(method) == block);
     s0_entity_free(method);
 }
@@ -1162,15 +1151,13 @@ TEST_CASE("literal ∈ *") {
 
 TEST_CASE("method ∈ *") {
     struct s0_entity_type  *type;
-    struct s0_name  *self_name;
     struct s0_block  *block;
     struct s0_entity  *entity;
     /* type = * */
     check_alloc(type, s0_any_entity_type_new());
     /* entity = method */
-    check_alloc(self_name, s0_name_new_str("self"));
     check_alloc(block, create_empty_block());
-    check_alloc(entity, s0_method_new(self_name, block));
+    check_alloc(entity, s0_method_new(block));
     /* Verify entity ∈ type */
     check(s0_entity_type_satisfied_by(type, entity));
     /* Free everything */
@@ -1291,7 +1278,6 @@ TEST_CASE("literal ∉ ⤿ ⦃a:*⦄") {
 
 TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
     struct s0_entity_type  *type;
-    struct s0_name  *self_name;
     struct s0_block  *block;
     struct s0_entity  *entity;
     /* type = ⤿ ⦃a:*⦄ */
@@ -1303,9 +1289,8 @@ TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
                 "    a: !s0!any {}\n"
                 ));
     /* entity = method */
-    check_alloc(self_name, s0_name_new_str("self"));
     check_alloc(block, create_empty_block());
-    check_alloc(entity, s0_method_new(self_name, block));
+    check_alloc(entity, s0_method_new(block));
     /* Verify entity ∉ type */
     check(!s0_entity_type_satisfied_by(type, entity));
     /* Free everything */
@@ -1991,7 +1976,6 @@ TEST_CASE("can add `create-literal` to environment type") {
 TEST_CASE("can add `create-method` to environment type") {
     struct s0_environment_type  *type;
     struct s0_name  *dest;
-    struct s0_name  *self_input;
     struct s0_block  *body;
     struct s0_statement  *stmt;
     struct s0_name  *name;
@@ -2000,9 +1984,8 @@ TEST_CASE("can add `create-method` to environment type") {
     /* Create environment from statement */
     check_alloc(type, s0_environment_type_new());
     check_alloc(dest, s0_name_new_str("a"));
-    check_alloc(self_input, s0_name_new_str("self"));
     check_alloc(body, create_empty_block());
-    check_alloc(stmt, s0_create_method_new(dest, self_input, body));
+    check_alloc(stmt, s0_create_method_new(dest, body));
     check0(s0_environment_type_add_statement(type, stmt));
     /* expected = * */
     check_alloc(expected, s0_any_entity_type_new());

--- a/tests/s0/parsing/create-method.yaml
+++ b/tests/s0/parsing/create-method.yaml
@@ -11,18 +11,20 @@ module:
   statements:
     - !s0!create-method
       dest: x
-      self-input: self
       body:
         inputs:
+          self: !s0!any {}
           exit: !s0!closure
             branches:
-              return: {}
+              return:
+                self: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
-          parameters: {}
+          parameters:
+            self: self
   invocation:
     !s0!invoke-closure
     src: exit
@@ -42,47 +44,20 @@ module:
           x: !s0!any {}
   statements:
     - !s0!create-method
-      self-input: self
       body:
         inputs:
-          exit: exit
-        statements: []
-        invocation:
-          !s0!invoke-closure
-          src: exit
-          branch: return
-          parameters: {}
-  invocation:
-    !s0!invoke-closure
-    src: exit
-    branch: return
-    parameters:
-      x: x
-
-%TAG !s0! tag:swanson-lang.org,2016:
----
-!s0!invalid-parse
-name: create-method needs a self input
-module:
-  inputs:
-    exit: !s0!closure
-      branches:
-        return:
-          x: !s0!any {}
-  statements:
-    - !s0!create-method
-      dest: x
-      body:
-        inputs:
+          self: !s0!any {}
           exit: !s0!closure
             branches:
-              return: {}
+              return:
+                self: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
-          parameters: {}
+          parameters:
+            self: self
   invocation:
     !s0!invoke-closure
     src: exit
@@ -103,7 +78,6 @@ module:
   statements:
     - !s0!create-method
       dest: x
-      self-input: self
   invocation:
     !s0!invoke-closure
     src: exit
@@ -125,18 +99,20 @@ module:
   statements:
     - !s0!create-method
       dest: x
-      self-input: self
       body:
         inputs:
+          self: !s0!any {}
           exit: !s0!closure
             branches:
-              return: {}
+              return:
+                self: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
-          parameters: {}
+          parameters:
+            self: self
   invocation:
     !s0!invoke-closure
     src: exit
@@ -157,32 +133,36 @@ module:
   statements:
     - !s0!create-method
       dest: x
-      self-input: self
       body:
         inputs:
+          self: !s0!any {}
           exit: !s0!closure
             branches:
-              return: {}
+              return:
+                self: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
-          parameters: {}
+          parameters:
+            self: self
     - !s0!create-method
       dest: x
-      self-input: self
       body:
         inputs:
+          self: !s0!any {}
           exit: !s0!closure
             branches:
-              return: {}
+              return:
+                self: !s0!any {}
         statements: []
         invocation:
           !s0!invoke-closure
           src: exit
           branch: return
-          parameters: {}
+          parameters:
+            self: self
   invocation:
     !s0!invoke-closure
     src: exit


### PR DESCRIPTION
Before, a method declared a `self_input` in addition to the normal set of inputs defined in the method's block.  The intention was that when invoking a method, we'd pass in the object containing the method as an additional entry in the environment, with `self_input` telling us which name to place it at.  We don't need to treat this specially, though; you can (er, must) now just include the "self" input along with any others in the method's block's `inputs` section.  Once we start type-checking method invocations, we'll make sure that there's an entry in the `parameters` section mapping the containing object to one of the inputs.