### PR TITLE
Verify method invocations

### DIFF
--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -419,13 +419,13 @@ size_t
 s0_literal_size(const struct s0_entity *);
 
 
-/* Takes control block */
+/* Takes control body */
 struct s0_entity *
-s0_method_new(struct s0_block *block);
+s0_method_new(struct s0_block *body);
 
 /* Entity MUST be a method.  method retains ownership of block. */
 struct s0_block *
-s0_method_block(const struct s0_entity *);
+s0_method_body(const struct s0_entity *);
 
 
 struct s0_object_entry {

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -473,6 +473,9 @@ enum s0_entity_type_kind {
 struct s0_entity_type *
 s0_entity_type_new_copy(const struct s0_entity_type *other);
 
+struct s0_entity_type *
+s0_entity_type_new_from_entity(const struct s0_entity *);
+
 void
 s0_entity_type_free(struct s0_entity_type *);
 
@@ -504,13 +507,6 @@ s0_any_entity_type_new(void);
 struct s0_entity_type *
 s0_closure_entity_type_new(struct s0_environment_type_mapping *branches);
 
-struct s0_entity_type *
-s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks);
-
-/* Entity MUST be a closure */
-struct s0_entity_type *
-s0_closure_entity_type_new_from_closure(struct s0_entity *entity);
-
 /* Retains ownership of result.  Type MUST be a closure type. */
 const struct s0_environment_type_mapping *
 s0_closure_entity_type_branches(const struct s0_entity_type *);
@@ -519,13 +515,6 @@ s0_closure_entity_type_branches(const struct s0_entity_type *);
 /* Takes ownership of branch */
 struct s0_entity_type *
 s0_method_entity_type_new(struct s0_environment_type *body);
-
-struct s0_entity_type *
-s0_method_entity_type_new_from_block(struct s0_block *block);
-
-/* Entity MUST be a method */
-struct s0_entity_type *
-s0_method_entity_type_new_from_method(struct s0_entity *entity);
 
 /* Retains ownership of result.  Type MUST be a method type. */
 const struct s0_environment_type *

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -467,7 +467,8 @@ struct s0_environment_type_mapping;
 enum s0_entity_type_kind {
     S0_ENTITY_TYPE_KIND_ANY,
     S0_ENTITY_TYPE_KIND_CLOSURE,
-    S0_ENTITY_TYPE_KIND_METHOD
+    S0_ENTITY_TYPE_KIND_METHOD,
+    S0_ENTITY_TYPE_KIND_OBJECT
 };
 
 struct s0_entity_type *
@@ -519,6 +520,15 @@ s0_method_entity_type_new(struct s0_environment_type *body);
 /* Retains ownership of result.  Type MUST be a method type. */
 const struct s0_environment_type *
 s0_method_entity_type_body(const struct s0_entity_type *);
+
+
+/* Takes ownership of elements */
+struct s0_entity_type *
+s0_object_entity_type_new(struct s0_environment_type *elements);
+
+/* Retains ownership of result.  Type MUST be a object type. */
+const struct s0_environment_type *
+s0_object_entity_type_elements(const struct s0_entity_type *);
 
 
 /*-----------------------------------------------------------------------------
@@ -684,6 +694,7 @@ s0_environment_type_mapping_get(const struct s0_environment_type_mapping *,
 #define S0_INVOKE_CLOSURE_TAG  SWANSON_TAG_PREFIX "invoke-closure"
 #define S0_INVOKE_METHOD_TAG   SWANSON_TAG_PREFIX "invoke-method"
 #define S0_METHOD_TAG          SWANSON_TAG_PREFIX "method"
+#define S0_OBJECT_TAG          SWANSON_TAG_PREFIX "object"
 
 
 struct s0_yaml_stream;

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -466,7 +466,8 @@ struct s0_environment_type_mapping;
 
 enum s0_entity_type_kind {
     S0_ENTITY_TYPE_KIND_ANY,
-    S0_ENTITY_TYPE_KIND_CLOSURE
+    S0_ENTITY_TYPE_KIND_CLOSURE,
+    S0_ENTITY_TYPE_KIND_METHOD
 };
 
 struct s0_entity_type *
@@ -503,7 +504,6 @@ s0_any_entity_type_new(void);
 struct s0_entity_type *
 s0_closure_entity_type_new(struct s0_environment_type_mapping *branches);
 
-/* Entity MUST be a closure */
 struct s0_entity_type *
 s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks);
 
@@ -513,7 +513,23 @@ s0_closure_entity_type_new_from_closure(struct s0_entity *entity);
 
 /* Retains ownership of result.  Type MUST be a closure type. */
 const struct s0_environment_type_mapping *
-s0_closure_entity_type_mapping(const struct s0_entity_type *);
+s0_closure_entity_type_branches(const struct s0_entity_type *);
+
+
+/* Takes ownership of branch */
+struct s0_entity_type *
+s0_method_entity_type_new(struct s0_environment_type *body);
+
+struct s0_entity_type *
+s0_method_entity_type_new_from_block(struct s0_block *block);
+
+/* Entity MUST be a method */
+struct s0_entity_type *
+s0_method_entity_type_new_from_method(struct s0_entity *entity);
+
+/* Retains ownership of result.  Type MUST be a method type. */
+const struct s0_environment_type *
+s0_method_entity_type_body(const struct s0_entity_type *);
 
 
 /*-----------------------------------------------------------------------------
@@ -678,6 +694,7 @@ s0_environment_type_mapping_get(const struct s0_environment_type_mapping *,
 #define S0_CREATE_METHOD_TAG   SWANSON_TAG_PREFIX "create-method"
 #define S0_INVOKE_CLOSURE_TAG  SWANSON_TAG_PREFIX "invoke-closure"
 #define S0_INVOKE_METHOD_TAG   SWANSON_TAG_PREFIX "invoke-method"
+#define S0_METHOD_TAG          SWANSON_TAG_PREFIX "method"
 
 
 struct s0_yaml_stream;

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -118,7 +118,7 @@ struct s0_entity {
             const void  *content;
         } literal;
         struct {
-            struct s0_block  *block;
+            struct s0_block  *body;
         } method;
         struct {
             size_t  size;
@@ -1152,29 +1152,29 @@ s0_literal_size(const struct s0_entity *literal)
 
 
 struct s0_entity *
-s0_method_new(struct s0_block *block)
+s0_method_new(struct s0_block *body)
 {
     struct s0_entity  *method = malloc(sizeof(struct s0_entity));
     if (unlikely(method == NULL)) {
-        s0_block_free(block);
+        s0_block_free(body);
         return NULL;
     }
     method->type = S0_ENTITY_KIND_METHOD;
-    method->_.method.block = block;
+    method->_.method.body = body;
     return method;
 }
 
 static void
 s0_method_free(struct s0_entity *method)
 {
-    s0_block_free(method->_.method.block);
+    s0_block_free(method->_.method.body);
 }
 
 struct s0_block *
-s0_method_block(const struct s0_entity *method)
+s0_method_body(const struct s0_entity *method)
 {
     assert(method->type == S0_ENTITY_KIND_METHOD);
-    return method->_.method.block;
+    return method->_.method.body;
 }
 
 

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -62,7 +62,7 @@ struct s0_named_blocks {
 };
 
 struct s0_statement {
-    enum s0_statement_kind  type;
+    enum s0_statement_kind  kind;
     union {
         struct {
             struct s0_name  *dest;
@@ -91,7 +91,7 @@ struct s0_statement_list {
 };
 
 struct s0_invocation {
-    enum s0_invocation_kind  type;
+    enum s0_invocation_kind  kind;
     union {
         struct {
             struct s0_name  *src;
@@ -107,7 +107,7 @@ struct s0_invocation {
 };
 
 struct s0_entity {
-    enum s0_entity_kind  type;
+    enum s0_entity_kind  kind;
     union {
         struct {
             struct s0_environment  *env;
@@ -665,7 +665,7 @@ s0_create_atom_new(struct s0_name *dest)
         s0_name_free(dest);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_KIND_CREATE_ATOM;
+    stmt->kind = S0_STATEMENT_KIND_CREATE_ATOM;
     stmt->_.create_atom.dest = dest;
     return stmt;
 }
@@ -679,7 +679,7 @@ s0_create_atom_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_atom_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_ATOM);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_ATOM);
     return stmt->_.create_atom.dest;
 }
 
@@ -695,7 +695,7 @@ s0_create_closure_new(struct s0_name *dest, struct s0_name_set *closed_over,
         s0_named_blocks_free(branches);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_KIND_CREATE_CLOSURE;
+    stmt->kind = S0_STATEMENT_KIND_CREATE_CLOSURE;
     stmt->_.create_closure.dest = dest;
     stmt->_.create_closure.closed_over = closed_over;
     stmt->_.create_closure.branches = branches;
@@ -713,21 +713,21 @@ s0_create_closure_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_closure_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.dest;
 }
 
 struct s0_name_set *
 s0_create_closure_closed_over(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.closed_over;
 }
 
 struct s0_named_blocks *
 s0_create_closure_branches(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_CLOSURE);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_CLOSURE);
     return stmt->_.create_closure.branches;
 }
 
@@ -740,7 +740,7 @@ s0_create_literal_new(struct s0_name *dest, size_t size, const void *content)
         s0_name_free(dest);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_KIND_CREATE_LITERAL;
+    stmt->kind = S0_STATEMENT_KIND_CREATE_LITERAL;
     stmt->_.create_literal.dest = dest;
     stmt->_.create_literal.size = size;
     stmt->_.create_literal.content = malloc(size);
@@ -763,21 +763,21 @@ s0_create_literal_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_literal_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.dest;
 }
 
 const void *
 s0_create_literal_content(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.content;
 }
 
 size_t
 s0_create_literal_size(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_LITERAL);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_LITERAL);
     return stmt->_.create_literal.size;
 }
 
@@ -791,7 +791,7 @@ s0_create_method_new(struct s0_name *dest, struct s0_block *body)
         s0_block_free(body);
         return NULL;
     }
-    stmt->type = S0_STATEMENT_KIND_CREATE_METHOD;
+    stmt->kind = S0_STATEMENT_KIND_CREATE_METHOD;
     stmt->_.create_method.dest = dest;
     stmt->_.create_method.body = body;
     return stmt;
@@ -807,14 +807,14 @@ s0_create_method_free(struct s0_statement *stmt)
 struct s0_name *
 s0_create_method_dest(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.dest;
 }
 
 struct s0_block *
 s0_create_method_body(const struct s0_statement *stmt)
 {
-    assert(stmt->type == S0_STATEMENT_KIND_CREATE_METHOD);
+    assert(stmt->kind == S0_STATEMENT_KIND_CREATE_METHOD);
     return stmt->_.create_method.body;
 }
 
@@ -822,7 +822,7 @@ s0_create_method_body(const struct s0_statement *stmt)
 void
 s0_statement_free(struct s0_statement *stmt)
 {
-    switch (stmt->type) {
+    switch (stmt->kind) {
         case S0_STATEMENT_KIND_CREATE_ATOM:
             s0_create_atom_free(stmt);
             break;
@@ -845,7 +845,7 @@ s0_statement_free(struct s0_statement *stmt)
 enum s0_statement_kind
 s0_statement_kind(const struct s0_statement *stmt)
 {
-    return stmt->type;
+    return stmt->kind;
 }
 
 
@@ -933,7 +933,7 @@ s0_invoke_closure_new(struct s0_name *src, struct s0_name *branch,
         s0_name_mapping_free(params);
         return NULL;
     }
-    invocation->type = S0_INVOCATION_KIND_INVOKE_CLOSURE;
+    invocation->kind = S0_INVOCATION_KIND_INVOKE_CLOSURE;
     invocation->_.invoke_closure.src = src;
     invocation->_.invoke_closure.branch = branch;
     invocation->_.invoke_closure.params = params;
@@ -951,21 +951,21 @@ s0_invoke_closure_free(struct s0_invocation *invocation)
 struct s0_name *
 s0_invoke_closure_src(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_CLOSURE);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_CLOSURE);
     return invocation->_.invoke_closure.src;
 }
 
 struct s0_name *
 s0_invoke_closure_branch(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_CLOSURE);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_CLOSURE);
     return invocation->_.invoke_closure.branch;
 }
 
 struct s0_name_mapping *
 s0_invoke_closure_params(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_CLOSURE);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_CLOSURE);
     return invocation->_.invoke_closure.params;
 }
 
@@ -981,7 +981,7 @@ s0_invoke_method_new(struct s0_name *src, struct s0_name *method,
         s0_name_mapping_free(params);
         return NULL;
     }
-    invocation->type = S0_INVOCATION_KIND_INVOKE_METHOD;
+    invocation->kind = S0_INVOCATION_KIND_INVOKE_METHOD;
     invocation->_.invoke_method.src = src;
     invocation->_.invoke_method.method = method;
     invocation->_.invoke_method.params = params;
@@ -999,21 +999,21 @@ s0_invoke_method_free(struct s0_invocation *invocation)
 struct s0_name *
 s0_invoke_method_src(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_METHOD);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_METHOD);
     return invocation->_.invoke_method.src;
 }
 
 struct s0_name *
 s0_invoke_method_method(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_METHOD);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_METHOD);
     return invocation->_.invoke_method.method;
 }
 
 struct s0_name_mapping *
 s0_invoke_method_params(const struct s0_invocation *invocation)
 {
-    assert(invocation->type == S0_INVOCATION_KIND_INVOKE_METHOD);
+    assert(invocation->kind == S0_INVOCATION_KIND_INVOKE_METHOD);
     return invocation->_.invoke_method.params;
 }
 
@@ -1021,7 +1021,7 @@ s0_invoke_method_params(const struct s0_invocation *invocation)
 void
 s0_invocation_free(struct s0_invocation *invocation)
 {
-    switch (invocation->type) {
+    switch (invocation->kind) {
         case S0_INVOCATION_KIND_INVOKE_CLOSURE:
             s0_invoke_closure_free(invocation);
             break;
@@ -1038,7 +1038,7 @@ s0_invocation_free(struct s0_invocation *invocation)
 enum s0_invocation_kind
 s0_invocation_kind(const struct s0_invocation *invocation)
 {
-    return invocation->type;
+    return invocation->kind;
 }
 
 
@@ -1053,7 +1053,7 @@ s0_atom_new(void)
     if (unlikely(atom == NULL)) {
         return NULL;
     }
-    atom->type = S0_ENTITY_KIND_ATOM;
+    atom->kind = S0_ENTITY_KIND_ATOM;
     return atom;
 }
 
@@ -1066,8 +1066,8 @@ s0_atom_free(struct s0_entity *atom)
 bool
 s0_atom_eq(const struct s0_entity *a1, const struct s0_entity *a2)
 {
-    assert(a1->type == S0_ENTITY_KIND_ATOM);
-    assert(a2->type == S0_ENTITY_KIND_ATOM);
+    assert(a1->kind == S0_ENTITY_KIND_ATOM);
+    assert(a2->kind == S0_ENTITY_KIND_ATOM);
     return (a1 == a2);
 }
 
@@ -1081,7 +1081,7 @@ s0_closure_new(struct s0_environment *env, struct s0_named_blocks *blocks)
         s0_named_blocks_free(blocks);
         return NULL;
     }
-    closure->type = S0_ENTITY_KIND_CLOSURE;
+    closure->kind = S0_ENTITY_KIND_CLOSURE;
     closure->_.closure.env = env;
     closure->_.closure.blocks = blocks;
     return closure;
@@ -1097,14 +1097,14 @@ s0_closure_free(struct s0_entity *closure)
 struct s0_environment *
 s0_closure_environment(const struct s0_entity *closure)
 {
-    assert(closure->type == S0_ENTITY_KIND_CLOSURE);
+    assert(closure->kind == S0_ENTITY_KIND_CLOSURE);
     return closure->_.closure.env;
 }
 
 struct s0_named_blocks *
 s0_closure_named_blocks(const struct s0_entity *closure)
 {
-    assert(closure->type == S0_ENTITY_KIND_CLOSURE);
+    assert(closure->kind == S0_ENTITY_KIND_CLOSURE);
     return closure->_.closure.blocks;
 }
 
@@ -1116,7 +1116,7 @@ s0_literal_new(size_t size, const void *content)
     if (unlikely(literal == NULL)) {
         return NULL;
     }
-    literal->type = S0_ENTITY_KIND_LITERAL;
+    literal->kind = S0_ENTITY_KIND_LITERAL;
     literal->_.literal.size = size;
     literal->_.literal.content = malloc(size);
     if (unlikely(literal->_.literal.content == NULL)) {
@@ -1142,14 +1142,14 @@ s0_literal_free(struct s0_entity *literal)
 const char *
 s0_literal_content(const struct s0_entity *literal)
 {
-    assert(literal->type == S0_ENTITY_KIND_LITERAL);
+    assert(literal->kind == S0_ENTITY_KIND_LITERAL);
     return literal->_.literal.content;
 }
 
 size_t
 s0_literal_size(const struct s0_entity *literal)
 {
-    assert(literal->type == S0_ENTITY_KIND_LITERAL);
+    assert(literal->kind == S0_ENTITY_KIND_LITERAL);
     return literal->_.literal.size;
 }
 
@@ -1162,7 +1162,7 @@ s0_method_new(struct s0_block *body)
         s0_block_free(body);
         return NULL;
     }
-    method->type = S0_ENTITY_KIND_METHOD;
+    method->kind = S0_ENTITY_KIND_METHOD;
     method->_.method.body = body;
     return method;
 }
@@ -1176,7 +1176,7 @@ s0_method_free(struct s0_entity *method)
 struct s0_block *
 s0_method_body(const struct s0_entity *method)
 {
-    assert(method->type == S0_ENTITY_KIND_METHOD);
+    assert(method->kind == S0_ENTITY_KIND_METHOD);
     return method->_.method.body;
 }
 
@@ -1190,7 +1190,7 @@ s0_object_new(void)
     if (unlikely(obj == NULL)) {
         return NULL;
     }
-    obj->type = S0_ENTITY_KIND_OBJECT;
+    obj->kind = S0_ENTITY_KIND_OBJECT;
     obj->_.obj.size = 0;
     obj->_.obj.allocated_size = DEFAULT_INITIAL_OBJECT_SIZE;
     obj->_.obj.entries =
@@ -1242,14 +1242,14 @@ s0_object_add(struct s0_entity *obj,
 size_t
 s0_object_size(const struct s0_entity *obj)
 {
-    assert(obj->type == S0_ENTITY_KIND_OBJECT);
+    assert(obj->kind == S0_ENTITY_KIND_OBJECT);
     return obj->_.obj.size;
 }
 
 struct s0_object_entry
 s0_object_at(const struct s0_entity *obj, size_t index)
 {
-    assert(obj->type == S0_ENTITY_KIND_OBJECT);
+    assert(obj->kind == S0_ENTITY_KIND_OBJECT);
     assert(index < obj->_.obj.size);
     return obj->_.obj.entries[index];
 }
@@ -1258,7 +1258,7 @@ struct s0_entity *
 s0_object_get(const struct s0_entity *obj, const struct s0_name *name)
 {
     size_t  i;
-    assert(obj->type == S0_ENTITY_KIND_OBJECT);
+    assert(obj->kind == S0_ENTITY_KIND_OBJECT);
     for (i = 0; i < obj->_.obj.size; i++) {
         if (s0_name_eq(obj->_.obj.entries[i].name, name)) {
             return obj->_.obj.entries[i].entity;
@@ -1271,7 +1271,7 @@ s0_object_get(const struct s0_entity *obj, const struct s0_name *name)
 void
 s0_entity_free(struct s0_entity *entity)
 {
-    switch (entity->type) {
+    switch (entity->kind) {
         case S0_ENTITY_KIND_ATOM:
             s0_atom_free(entity);
             break;
@@ -1297,7 +1297,7 @@ s0_entity_free(struct s0_entity *entity)
 enum s0_entity_kind
 s0_entity_kind(const struct s0_entity *entity)
 {
-    return entity->type;
+    return entity->kind;
 }
 
 
@@ -1399,7 +1399,7 @@ s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks)
 struct s0_entity_type *
 s0_closure_entity_type_new_from_closure(struct s0_entity *entity)
 {
-    assert(entity->type == S0_ENTITY_KIND_CLOSURE);
+    assert(entity->kind == S0_ENTITY_KIND_CLOSURE);
     return s0_closure_entity_type_new_from_named_blocks
         (entity->_.closure.blocks);
 }
@@ -1435,7 +1435,7 @@ s0_closure_entity_type_satisfied_by(const struct s0_entity_type *type,
     struct s0_environment_type_mapping  *branches;
     struct s0_named_blocks  *blocks;
 
-    if (entity->type != S0_ENTITY_KIND_CLOSURE) {
+    if (entity->kind != S0_ENTITY_KIND_CLOSURE) {
         return false;
     }
 
@@ -1531,7 +1531,7 @@ s0_method_entity_type_new_from_block(struct s0_block *block)
 struct s0_entity_type *
 s0_method_entity_type_new_from_method(struct s0_entity *entity)
 {
-    assert(entity->type == S0_ENTITY_KIND_METHOD);
+    assert(entity->kind == S0_ENTITY_KIND_METHOD);
     return s0_method_entity_type_new_from_block(entity->_.method.body);
 }
 
@@ -1564,7 +1564,7 @@ s0_method_entity_type_satisfied_by(const struct s0_entity_type *type,
 {
     struct s0_environment_type  *body_type;
     struct s0_block  *body;
-    if (entity->type != S0_ENTITY_KIND_METHOD) {
+    if (entity->kind != S0_ENTITY_KIND_METHOD) {
         return false;
     }
     body_type = type->_.method.body;
@@ -2000,7 +2000,7 @@ int
 s0_environment_type_add_statement(struct s0_environment_type *type,
                                   const struct s0_statement *stmt)
 {
-    switch (stmt->type) {
+    switch (stmt->kind) {
         case S0_STATEMENT_KIND_CREATE_ATOM:
             return s0_environment_type_add_create_atom(type, stmt);
         case S0_STATEMENT_KIND_CREATE_CLOSURE:
@@ -2086,7 +2086,7 @@ int
 s0_environment_type_add_invocation(struct s0_environment_type *type,
                                    const struct s0_invocation *invocation)
 {
-    switch (invocation->type) {
+    switch (invocation->kind) {
         case S0_INVOCATION_KIND_INVOKE_CLOSURE:
             return s0_environment_type_add_invoke_closure(type, invocation);
         case S0_INVOCATION_KIND_INVOKE_METHOD:

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -1356,8 +1356,9 @@ s0_closure_entity_type_new(struct s0_environment_type_mapping *branches)
     return type;
 }
 
-struct s0_entity_type *
-s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks)
+static struct s0_entity_type *
+s0_closure_entity_type_new_from_named_blocks(
+        const struct s0_named_blocks *blocks)
 {
     struct s0_environment_type_mapping  *branches;
     struct s0_named_blocks_entry  *curr;
@@ -1396,8 +1397,8 @@ s0_closure_entity_type_new_from_named_blocks(struct s0_named_blocks *blocks)
     return s0_closure_entity_type_new(branches);
 }
 
-struct s0_entity_type *
-s0_closure_entity_type_new_from_closure(struct s0_entity *entity)
+static struct s0_entity_type *
+s0_closure_entity_type_new_from_closure(const struct s0_entity *entity)
 {
     assert(entity->kind == S0_ENTITY_KIND_CLOSURE);
     return s0_closure_entity_type_new_from_named_blocks
@@ -1516,8 +1517,8 @@ s0_method_entity_type_new(struct s0_environment_type *body)
     return type;
 }
 
-struct s0_entity_type *
-s0_method_entity_type_new_from_block(struct s0_block *block)
+static struct s0_entity_type *
+s0_method_entity_type_new_from_block(const struct s0_block *block)
 {
     struct s0_environment_type  *inputs = block->inputs;
     struct s0_environment_type  *body;
@@ -1528,8 +1529,8 @@ s0_method_entity_type_new_from_block(struct s0_block *block)
     return s0_method_entity_type_new(body);
 }
 
-struct s0_entity_type *
-s0_method_entity_type_new_from_method(struct s0_entity *entity)
+static struct s0_entity_type *
+s0_method_entity_type_new_from_method(const struct s0_entity *entity)
 {
     assert(entity->kind == S0_ENTITY_KIND_METHOD);
     return s0_method_entity_type_new_from_block(entity->_.method.body);
@@ -1600,6 +1601,26 @@ s0_entity_type_new_copy(const struct s0_entity_type *other)
         case S0_ENTITY_TYPE_KIND_METHOD:
             return s0_method_entity_type_new_copy(other);
             break;
+        default:
+            assert(false);
+            break;
+    }
+}
+
+struct s0_entity_type *
+s0_entity_type_new_from_entity(const struct s0_entity *entity)
+{
+    switch (entity->kind) {
+        case S0_ENTITY_KIND_ATOM:
+            return s0_any_entity_type_new();
+        case S0_ENTITY_KIND_CLOSURE:
+            return s0_closure_entity_type_new_from_closure(entity);
+        case S0_ENTITY_KIND_LITERAL:
+            return s0_any_entity_type_new();
+        case S0_ENTITY_KIND_METHOD:
+            return s0_method_entity_type_new_from_method(entity);
+        case S0_ENTITY_KIND_OBJECT:
+            return s0_any_entity_type_new();
         default:
             assert(false);
             break;

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -422,6 +422,32 @@ s0_load_closure_entity_type(struct s0_yaml_node node)
 }
 
 static struct s0_entity_type *
+s0_load_method_entity_type(struct s0_yaml_node node)
+{
+    /* We've already verified that this is a !s0!method mapping node. */
+    struct s0_yaml_node  item;
+    struct s0_environment_type  *inputs;
+
+    /* inputs */
+
+    item = s0_yaml_node_mapping_get(node, "inputs");
+    if (unlikely(s0_yaml_node_is_missing(item))) {
+        fill_error(node.stream,
+                   "method entity type requires a inputs at %zu:%zu",
+                   s0_yaml_node_get_node(node)->start_mark.line,
+                   s0_yaml_node_get_node(node)->start_mark.column);
+        return NULL;
+    }
+
+    inputs = s0_load_environment_type(item);
+    if (unlikely(inputs == NULL)) {
+        return NULL;
+    }
+
+    return s0_method_entity_type_new(inputs);
+}
+
+static struct s0_entity_type *
 s0_load_entity_type(struct s0_yaml_node node)
 {
     ensure_mapping(node, "entity type");
@@ -429,6 +455,8 @@ s0_load_entity_type(struct s0_yaml_node node)
         return s0_load_any_entity_type(node);
     } else if (s0_yaml_node_has_tag(node, S0_CLOSURE_TAG)) {
         return s0_load_closure_entity_type(node);
+    } else if (s0_yaml_node_has_tag(node, S0_METHOD_TAG)) {
+        return s0_load_method_entity_type(node);
     } else {
         fill_error(node.stream, "Unknown entity type at %zu:%zu",
                    s0_yaml_node_get_node(node)->start_mark.line,

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -448,6 +448,18 @@ s0_load_method_entity_type(struct s0_yaml_node node)
 }
 
 static struct s0_entity_type *
+s0_load_object_entity_type(struct s0_yaml_node node)
+{
+    /* We've already verified that this is a !s0!object mapping node. */
+    struct s0_environment_type  *elements;
+    elements = s0_load_environment_type(node);
+    if (unlikely(elements == NULL)) {
+        return NULL;
+    }
+    return s0_object_entity_type_new(elements);
+}
+
+static struct s0_entity_type *
 s0_load_entity_type(struct s0_yaml_node node)
 {
     ensure_mapping(node, "entity type");
@@ -457,6 +469,8 @@ s0_load_entity_type(struct s0_yaml_node node)
         return s0_load_closure_entity_type(node);
     } else if (s0_yaml_node_has_tag(node, S0_METHOD_TAG)) {
         return s0_load_method_entity_type(node);
+    } else if (s0_yaml_node_has_tag(node, S0_OBJECT_TAG)) {
+        return s0_load_object_entity_type(node);
     } else {
         fill_error(node.stream, "Unknown entity type at %zu:%zu",
                    s0_yaml_node_get_node(node)->start_mark.line,

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1458,8 +1458,7 @@ TEST_CASE("type of ⟨⤿ ⦃a:*⦄ ...⟩ = ⤿ ⦃a:*⦄") {
     check_alloc(entity, s0_closure_new(env, blocks));
     /* Verify type(entity) = type */
     check_alloc(calculated_type, s0_entity_type_new_from_entity(entity));
-    check(s0_entity_type_satisfied_by_type(type, calculated_type));
-    check(s0_entity_type_satisfied_by_type(calculated_type, type));
+    check(s0_entity_type_equiv(type, calculated_type));
     /* Free everything */
     s0_entity_free(entity);
     s0_entity_type_free(type);
@@ -1705,8 +1704,281 @@ TEST_CASE("type of ⟨⊶ ⦃a:*⦄ ...⟩ = ⊶ ⦃a:*⦄") {
     check_alloc(entity, s0_method_new(body));
     /* Verify type(entity) = type */
     check_alloc(calculated_type, s0_entity_type_new_from_entity(entity));
-    check(s0_entity_type_satisfied_by_type(type, calculated_type));
-    check(s0_entity_type_satisfied_by_type(calculated_type, type));
+    check(s0_entity_type_equiv(type, calculated_type));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+    s0_entity_type_free(calculated_type);
+}
+
+/*-----------------------------------------------------------------------------
+ * S₀: Entity types: Objects
+ */
+
+TEST_CASE_GROUP("S₀ entity types: objects");
+
+TEST_CASE("can load ⟪a:*⟫ from string") {
+    struct s0_environment_type  *elements_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *expected;
+    struct s0_entity_type  *actual;
+    /* expected = ⟪a:*⟫ */
+    check_alloc(elements_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(elements_type, name, input_type));
+    check_alloc(expected, s0_object_entity_type_new(elements_type));
+    /* Load type from YAML string */
+    check_alloc(actual, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* Verify actual == expected */
+    check(s0_entity_type_equiv(actual, expected));
+    /* Free everything */
+    s0_entity_type_free(actual);
+    s0_entity_type_free(expected);
+}
+
+TEST_CASE("can copy ⟪a:*⟫") {
+    struct s0_entity_type  *type1;
+    struct s0_entity_type  *type2;
+    /* type1 = ⟪a:*⟫ */
+    check_alloc(type1, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* type2 = type1 */
+    check_alloc(type2, s0_entity_type_new_copy(type1));
+    /* Verify type1 == type2 */
+    check(s0_entity_type_equiv(type1, type2));
+    /* Free everything */
+    s0_entity_type_free(type1);
+    s0_entity_type_free(type2);
+}
+
+TEST_CASE("⋄ ∉ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⋄ */
+    check_alloc(entity, s0_atom_new());
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨⤿ ⦃a:*⦄ ...⟩ ∉ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_environment  *env;
+    struct s0_named_blocks  *blocks;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⟨⤿ ⦃a:*⦄ ...⟩ */
+    check_alloc(env, s0_environment_new());
+    check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_closure_new(src, branch, params));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_named_blocks_add(blocks, name, block));
+    check_alloc(entity, s0_closure_new(env, blocks));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("literal ∉ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = literal */
+    check_alloc(entity, s0_literal_new_str("hello"));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨⊶ ⦃a:*⦄ ...⟩ ∉ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⟨⊶ ⦃a:*⦄ ...⟩ */
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(entity, s0_method_new(block));
+    /* Verify entity ∈ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨a:⋄⟩ ∈ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    struct s0_name  *name;
+    struct s0_entity  *element;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⟨a:⋄⟩ */
+    check_alloc(entity, s0_object_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(element, s0_atom_new());
+    check0(s0_object_add(entity, name, element));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨a:⋄,b:⋄⟩ ∈ ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    struct s0_name  *name;
+    struct s0_entity  *element;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⟨a:⋄,b:⋄⟩ */
+    check_alloc(entity, s0_object_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(element, s0_atom_new());
+    check0(s0_object_add(entity, name, element));
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(element, s0_atom_new());
+    check0(s0_object_add(entity, name, element));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨a:⋄⟩ ∉ ⟪a:*,b:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    struct s0_name  *name;
+    struct s0_entity  *element;
+    /* type = ⟪a:*,b:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                "b: !s0!any {}\n"
+                ));
+    /* entity = ⟨a:⋄⟩ */
+    check_alloc(entity, s0_object_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(element, s0_atom_new());
+    check0(s0_object_add(entity, name, element));
+    /* Verify entity ∈ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("type of ⟨a:⋄⟩ = ⟪a:*⟫") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    struct s0_name  *name;
+    struct s0_entity  *element;
+    struct s0_entity_type  *calculated_type;
+    /* type = ⟪a:*⟫ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* entity = ⟨a:⋄⟩ */
+    check_alloc(entity, s0_object_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(element, s0_atom_new());
+    check0(s0_object_add(entity, name, element));
+    /* Verify type(entity) = type */
+    check_alloc(calculated_type, s0_entity_type_new_from_entity(entity));
+    check(s0_entity_type_equiv(type, calculated_type));
     /* Free everything */
     s0_entity_free(entity);
     s0_entity_type_free(type);
@@ -1815,6 +2087,74 @@ TEST_CASE("⊶ ⦃a:*⦄ ⊆ ⊶ ⦃a:*⦄") {
                 "!s0!method\n"
                 "inputs:\n"
                 "  a: !s0!any {}\n"
+                ));
+    /* Verify have ⊆ requires */
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⟪a:*⟫ ⊆ ⟪a:*⟫") {
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = ⟪a:*⟫ */
+    check_alloc(requires, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* have = ⟪a:*⟫ */
+    check_alloc(have, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* Verify have ⊆ requires */
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⟪a:*⟫ ⊈ ⟪a:*,b:*⟫") {
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = ⟪a:*⟫ */
+    check_alloc(requires, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                "b: !s0!any {}\n"
+                ));
+    /* have = ⟪a:*⟫ */
+    check_alloc(have, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* Verify have ⊈ requires */
+    check(!s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⟪a:*,b:*⟫ ⊆ ⟪a:*⟫") {
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = ⟪a:*⟫ */
+    check_alloc(requires, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                ));
+    /* have = ⟪a:*,b:*⟫ */
+    check_alloc(have, entity_type(
+                YAML
+                "!s0!object\n"
+                "a: !s0!any {}\n"
+                "b: !s0!any {}\n"
                 ));
     /* Verify have ⊆ requires */
     check(s0_entity_type_satisfied_by_type(requires, have));

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1457,8 +1457,7 @@ TEST_CASE("type of ⟨⤿ ⦃a:*⦄ ...⟩ = ⤿ ⦃a:*⦄") {
     check0(s0_named_blocks_add(blocks, name, block));
     check_alloc(entity, s0_closure_new(env, blocks));
     /* Verify type(entity) = type */
-    check_alloc(calculated_type,
-                s0_closure_entity_type_new_from_closure(entity));
+    check_alloc(calculated_type, s0_entity_type_new_from_entity(entity));
     check(s0_entity_type_satisfied_by_type(type, calculated_type));
     check(s0_entity_type_satisfied_by_type(calculated_type, type));
     /* Free everything */
@@ -1705,8 +1704,7 @@ TEST_CASE("type of ⟨⊶ ⦃a:*⦄ ...⟩ = ⊶ ⦃a:*⦄") {
     check_alloc(body, s0_block_new(inputs, statements, invocation));
     check_alloc(entity, s0_method_new(body));
     /* Verify type(entity) = type */
-    check_alloc(calculated_type,
-                s0_method_entity_type_new_from_method(entity));
+    check_alloc(calculated_type, s0_entity_type_new_from_entity(entity));
     check(s0_entity_type_satisfied_by_type(type, calculated_type));
     check(s0_entity_type_satisfied_by_type(calculated_type, type));
     /* Free everything */

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -792,11 +792,11 @@ TEST_CASE_GROUP("S₀ methods");
 
 TEST_CASE("can create method") {
     struct s0_entity  *method;
-    struct s0_block  *block;
-    check_alloc(block, create_empty_block());
-    check_alloc(method, s0_method_new(block));
+    struct s0_block  *body;
+    check_alloc(body, create_empty_block());
+    check_alloc(method, s0_method_new(body));
     check(s0_entity_kind(method) == S0_ENTITY_KIND_METHOD);
-    check(s0_method_block(method) == block);
+    check(s0_method_body(method) == body);
     s0_entity_free(method);
 }
 
@@ -1151,13 +1151,13 @@ TEST_CASE("literal ∈ *") {
 
 TEST_CASE("method ∈ *") {
     struct s0_entity_type  *type;
-    struct s0_block  *block;
+    struct s0_block  *body;
     struct s0_entity  *entity;
     /* type = * */
     check_alloc(type, s0_any_entity_type_new());
     /* entity = method */
-    check_alloc(block, create_empty_block());
-    check_alloc(entity, s0_method_new(block));
+    check_alloc(body, create_empty_block());
+    check_alloc(entity, s0_method_new(body));
     /* Verify entity ∈ type */
     check(s0_entity_type_satisfied_by(type, entity));
     /* Free everything */
@@ -1278,7 +1278,7 @@ TEST_CASE("literal ∉ ⤿ ⦃a:*⦄") {
 
 TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
     struct s0_entity_type  *type;
-    struct s0_block  *block;
+    struct s0_block  *body;
     struct s0_entity  *entity;
     /* type = ⤿ ⦃a:*⦄ */
     check_alloc(type, entity_type(
@@ -1289,8 +1289,8 @@ TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
                 "    a: !s0!any {}\n"
                 ));
     /* entity = method */
-    check_alloc(block, create_empty_block());
-    check_alloc(entity, s0_method_new(block));
+    check_alloc(body, create_empty_block());
+    check_alloc(entity, s0_method_new(body));
     /* Verify entity ∉ type */
     check(!s0_entity_type_satisfied_by(type, entity));
     /* Free everything */

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -1149,14 +1149,36 @@ TEST_CASE("literal ∈ *") {
     s0_entity_type_free(type);
 }
 
-TEST_CASE("method ∈ *") {
+TEST_CASE("⟨⊶ ⦃a:*⦄ ...⟩ ∈ *") {
     struct s0_entity_type  *type;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
     struct s0_block  *body;
     struct s0_entity  *entity;
     /* type = * */
     check_alloc(type, s0_any_entity_type_new());
-    /* entity = method */
-    check_alloc(body, create_empty_block());
+    /* entity = ⟨⊶ ⦃a:*⦄ ...⟩ */
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(body, s0_block_new(inputs, statements, invocation));
     check_alloc(entity, s0_method_new(body));
     /* Verify entity ∈ type */
     check(s0_entity_type_satisfied_by(type, entity));
@@ -1276,8 +1298,18 @@ TEST_CASE("literal ∉ ⤿ ⦃a:*⦄") {
     s0_entity_type_free(type);
 }
 
-TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
+TEST_CASE("⟨⊶ ⦃a:*⦄ ...⟩ ∉ ⤿ ⦃a:*⦄") {
     struct s0_entity_type  *type;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
     struct s0_block  *body;
     struct s0_entity  *entity;
     /* type = ⤿ ⦃a:*⦄ */
@@ -1288,8 +1320,20 @@ TEST_CASE("method ∉ ⤿ ⦃a:*⦄") {
                 "  cont:\n"
                 "    a: !s0!any {}\n"
                 ));
-    /* entity = method */
-    check_alloc(body, create_empty_block());
+    /* entity = ⟨⊶ ⦃a:*⦄ ...⟩ */
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(body, s0_block_new(inputs, statements, invocation));
     check_alloc(entity, s0_method_new(body));
     /* Verify entity ∉ type */
     check(!s0_entity_type_satisfied_by(type, entity));
@@ -1424,6 +1468,254 @@ TEST_CASE("type of ⟨⤿ ⦃a:*⦄ ...⟩ = ⤿ ⦃a:*⦄") {
 }
 
 /*-----------------------------------------------------------------------------
+ * S₀: Entity types: Methods
+ */
+
+TEST_CASE_GROUP("S₀ entity types: methods");
+
+TEST_CASE("can load ⊶ ⦃a:*⦄ from string") {
+    struct s0_environment_type  *body_type;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_entity_type  *expected;
+    struct s0_entity_type  *actual;
+    /* expected = ⊶ ⦃a:*⦄ */
+    check_alloc(body_type, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(body_type, name, input_type));
+    check_alloc(expected, s0_method_entity_type_new(body_type));
+    /* Load type from YAML string */
+    check_alloc(actual, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* Verify actual == expected */
+    check(s0_entity_type_equiv(actual, expected));
+    /* Free everything */
+    s0_entity_type_free(actual);
+    s0_entity_type_free(expected);
+}
+
+TEST_CASE("can copy ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type1;
+    struct s0_entity_type  *type2;
+    /* type1 = ⊶ ⦃a:*⦄ */
+    check_alloc(type1, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* type2 = type1 */
+    check_alloc(type2, s0_entity_type_new_copy(type1));
+    /* Verify type1 == type2 */
+    check(s0_entity_type_equiv(type1, type2));
+    /* Free everything */
+    s0_entity_type_free(type1);
+    s0_entity_type_free(type2);
+}
+
+TEST_CASE("⋄ ∉ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = ⋄ */
+    check_alloc(entity, s0_atom_new());
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨⤿ ⦃a:*⦄ ...⟩ ∉ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_environment  *env;
+    struct s0_named_blocks  *blocks;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
+    struct s0_block  *block;
+    struct s0_entity  *entity;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = ⟨⤿ ⦃a:*⦄ ...⟩ */
+    check_alloc(env, s0_environment_new());
+    check_alloc(blocks, s0_named_blocks_new());
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(block, s0_block_new(inputs, statements, invocation));
+    check_alloc(name, s0_name_new_str("cont"));
+    check0(s0_named_blocks_add(blocks, name, block));
+    check_alloc(entity, s0_closure_new(env, blocks));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("literal ∉ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = literal */
+    check_alloc(entity, s0_literal_new_str("hello"));
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("object ∉ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_entity  *entity;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = object */
+    check_alloc(entity, s0_object_new());
+    /* Verify entity ∉ type */
+    check(!s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("⟨⊶ ⦃a:*⦄ ...⟩ ∈ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
+    struct s0_block  *body;
+    struct s0_entity  *entity;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = ⟨⊶ ⦃a:*⦄ ...⟩ */
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(body, s0_block_new(inputs, statements, invocation));
+    check_alloc(entity, s0_method_new(body));
+    /* Verify entity ∈ type */
+    check(s0_entity_type_satisfied_by(type, entity));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+}
+
+TEST_CASE("type of ⟨⊶ ⦃a:*⦄ ...⟩ = ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *type;
+    struct s0_environment_type  *inputs;
+    struct s0_name  *name;
+    struct s0_entity_type  *input_type;
+    struct s0_statement_list  *statements;
+    struct s0_name  *src;
+    struct s0_name  *branch;
+    struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
+    struct s0_invocation  *invocation;
+    struct s0_block  *body;
+    struct s0_entity  *entity;
+    struct s0_entity_type  *calculated_type;
+    /* type = ⊶ ⦃a:*⦄ */
+    check_alloc(type, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* entity = ⟨⊶ ⦃a:*⦄ ...⟩ */
+    check_alloc(inputs, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(input_type, s0_any_entity_type_new());
+    check0(s0_environment_type_add(inputs, name, input_type));
+    check_alloc(statements, s0_statement_list_new());
+    check_alloc(src, s0_name_new_str("a"));
+    check_alloc(branch, s0_name_new_str("cont"));
+    check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("a"));
+    check0(s0_name_mapping_add(params, from, to));
+    check_alloc(invocation, s0_invoke_method_new(src, branch, params));
+    check_alloc(body, s0_block_new(inputs, statements, invocation));
+    check_alloc(entity, s0_method_new(body));
+    /* Verify type(entity) = type */
+    check_alloc(calculated_type,
+                s0_method_entity_type_new_from_method(entity));
+    check(s0_entity_type_satisfied_by_type(type, calculated_type));
+    check(s0_entity_type_satisfied_by_type(calculated_type, type));
+    /* Free everything */
+    s0_entity_free(entity);
+    s0_entity_type_free(type);
+    s0_entity_type_free(calculated_type);
+}
+
+/*-----------------------------------------------------------------------------
  * S₀: Entity types: Subtyping
  */
 
@@ -1486,7 +1778,7 @@ TEST_CASE("* ⊈ ⤿ ⦃a:*⦄") {
 TEST_CASE("⤿ ⦃a:*⦄ ⊆ ⤿ ⦃a:*⦄") {
     struct s0_entity_type  *requires;
     struct s0_entity_type  *have;
-    /* requires = * */
+    /* requires = ⤿ ⦃a:*⦄ */
     check_alloc(requires, entity_type(
                 YAML
                 "!s0!closure\n"
@@ -1501,6 +1793,30 @@ TEST_CASE("⤿ ⦃a:*⦄ ⊆ ⤿ ⦃a:*⦄") {
                 "branches:\n"
                 "  cont:\n"
                 "    a: !s0!any {}\n"
+                ));
+    /* Verify have ⊆ requires */
+    check(s0_entity_type_satisfied_by_type(requires, have));
+    /* Free everything */
+    s0_entity_type_free(requires);
+    s0_entity_type_free(have);
+}
+
+TEST_CASE("⊶ ⦃a:*⦄ ⊆ ⊶ ⦃a:*⦄") {
+    struct s0_entity_type  *requires;
+    struct s0_entity_type  *have;
+    /* requires = ⊶ ⦃a:*⦄ */
+    check_alloc(requires, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
+                ));
+    /* have = ⊶ ⦃a:*⦄ */
+    check_alloc(have, entity_type(
+                YAML
+                "!s0!method\n"
+                "inputs:\n"
+                "  a: !s0!any {}\n"
                 ));
     /* Verify have ⊆ requires */
     check(s0_entity_type_satisfied_by_type(requires, have));

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -2687,24 +2687,30 @@ TEST_CASE("can add `invoke-closure` to environment type") {
 
 TEST_CASE("can add `invoke-method` to environment type") {
     struct s0_environment_type  *type;
-    struct s0_name  *name;
-    struct s0_entity_type  *etype;
     struct s0_name  *src;
     struct s0_name  *method;
     struct s0_name_mapping  *params;
+    struct s0_name  *from;
+    struct s0_name  *to;
     struct s0_invocation  *invocation;
-    check_alloc(type, s0_environment_type_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check_alloc(etype, s0_any_entity_type_new());
-    check0(s0_environment_type_add(type, name, etype));
+    /* initial env = ⦃a:⟪run:⊶ ⦃self:*⦄⟫⦄ */
+    check_alloc(type, environment_type(
+                YAML
+                "a: !s0!object\n"
+                "  run: !s0!method\n"
+                "    inputs:\n"
+                "      self: !s0!any {}\n"
+                ));
+    /* Then add the invocation */
     check_alloc(src, s0_name_new_str("a"));
     check_alloc(method, s0_name_new_str("run"));
     check_alloc(params, s0_name_mapping_new());
+    check_alloc(from, s0_name_new_str("a"));
+    check_alloc(to, s0_name_new_str("self"));
+    check0(s0_name_mapping_add(params, from, to));
     check_alloc(invocation, s0_invoke_method_new(src, method, params));
     check0(s0_environment_type_add_invocation(type, invocation));
-    check_alloc(name, s0_name_new_str("a"));
-    check(s0_environment_type_get(type, name) == NULL);
-    s0_name_free(name);
+    /* Free everything */
     s0_invocation_free(invocation);
     s0_environment_type_free(type);
 }

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -149,7 +149,7 @@ module:
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!successful-parse
-name: The name of a parameter can change
+name: The name of a closure parameter can change
 module:
   inputs:
     x: !s0!any {}
@@ -168,7 +168,7 @@ module:
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!successful-parse
-name: The name of a parameter doesn't need to change
+name: The name of a closure parameter doesn't need to change
 module:
   inputs:
     x: !s0!any {}
@@ -187,7 +187,7 @@ module:
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!successful-parse
-name: All of the renamings happen "at the same time"
+name: All of the closure parameter renamings happen "at the same time"
 module:
   inputs:
     x: !s0!any {}
@@ -209,7 +209,7 @@ module:
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!invalid-parse
-name: There cannot be multiple parameters with the same "from" name
+name: There cannot be multiple closure parameters with the same "from" name
 module:
   inputs:
     x: !s0!any {}
@@ -230,7 +230,7 @@ module:
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!invalid-parse
-name: There cannot be multiple parameters with the same "to" name
+name: There cannot be multiple closure parameters with the same "to" name
 module:
   inputs:
     x: !s0!any {}
@@ -246,7 +246,7 @@ module:
     branch: return
     parameters:
       x: x
-      x: x
+      y: x
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---

--- a/tests/s0/parsing/invoke-method.yaml
+++ b/tests/s0/parsing/invoke-method.yaml
@@ -4,13 +4,17 @@
 name: invoke-method can call a method in the environment
 module:
   inputs:
-    self: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     src: self
     method: id
-    parameters: {}
+    parameters:
+      self: self
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -18,14 +22,16 @@ module:
 name: invoke-method needs a source
 module:
   inputs:
-module:
-  inputs:
-    self: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     method: id
-    parameters: {}
+    parameters:
+      self: self
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
@@ -33,30 +39,347 @@ module:
 name: invoke-method needs a method
 module:
   inputs:
-    self: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     src: self
-    parameters: {}
+    parameters:
+      self: self
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
 !s0!invalid-parse
-name: invoke-method needs a param
+name: invoke-method needs parameters
 module:
   inputs:
-    self: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
   statements: []
   invocation:
     !s0!invoke-method
     src: self
     method: id
 
-# TODO - invoke-method cannot call a missing environment entry
-# TODO - invoke-method cannot call an atom
-# TODO - invoke-method cannot call a closure
-# TODO - invoke-method cannot call a literal
-# TODO - invoke-method cannot call a method
-# TODO - invoke-method cannot call a missing method
-# TODO - invoke-method environment must satisfy the inputs of its target
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call a missing environment entry
+module:
+  inputs: {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call an atom
+module:
+  inputs: {}
+  statements:
+    - !s0!create-atom
+      dest: self
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call a closure
+module:
+  inputs: {}
+  statements:
+    - !s0!create-closure
+      dest: self
+      closed-over: []
+      branches:
+        body:
+          inputs:
+            exit: !s0!closure
+              branches:
+                return: {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: exit
+            branch: return
+            parameters: {}
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call a literal
+module:
+  inputs: {}
+  statements:
+    - !s0!create-literal
+      dest: self
+      content: stuff
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call a method outside of an object
+module:
+  inputs: {}
+  statements:
+    - !s0!create-method
+      dest: self
+      self-input: self
+      body:
+        inputs:
+          exit: !s0!closure
+            branches:
+              return: {}
+        statements: []
+        invocation:
+          !s0!invoke-closure
+          src: exit
+          branch: return
+          parameters: {}
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot call a missing method
+module:
+  inputs:
+    self: !s0!object
+      other: !s0!method
+        inputs:
+          self: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: The name of a method parameter can change
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: y
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: The name of a method parameter doesn't need to change
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!successful-parse
+name: All of the method parameter renamings happen "at the same time"
+module:
+  inputs:
+    x: !s0!any {}
+    y: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!any {}
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: y
+      y: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple method parameters with the same "from" name
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!any {}
+          y: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: x
+      x: y
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: There cannot be multiple method parameters with the same "to" name
+module:
+  inputs:
+    x: !s0!any {}
+    y: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: x
+      y: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method must provide a parameter for "self"
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      x: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method must provide a parameter for each input
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method parameter must satisfy input type
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+          x: !s0!closure
+            branches:
+              abort: {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
+!s0!invalid-parse
+name: invoke-method cannot provide extra parameters
+module:
+  inputs:
+    x: !s0!any {}
+    self: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+  statements: []
+  invocation:
+    !s0!invoke-method
+    src: self
+    method: id
+    parameters:
+      self: self
+      x: x
+
+# TODO - invoke-method cannot call an object


### PR DESCRIPTION
We need to verify method invocations, just like we do with closure invocations.  To do that, we need types that describe methods and objects.