### PR TITLE
[c] Produce useful error messages

### DIFF
--- a/c/Makefile.deps
+++ b/c/Makefile.deps
@@ -1,8 +1,9 @@
 $(BUILD_ROOT)/objs/libswanson/s0.o: \
  $(SOURCE_ROOT)/libswanson/s0.c \
  $(SOURCE_ROOT)/include/swanson.h \
- $(SOURCE_ROOT)/ccan/likely/likely.h \
- $(SOURCE_ROOT)/include/config.h
+ $(SOURCE_ROOT)/ccan/compiler/compiler.h \
+ $(SOURCE_ROOT)/include/config.h \
+ $(SOURCE_ROOT)/ccan/likely/likely.h
 $(BUILD_ROOT)/objs/libswanson/yaml.o: \
  $(SOURCE_ROOT)/libswanson/yaml.c \
  $(SOURCE_ROOT)/include/swanson.h \

--- a/c/include/config.h
+++ b/c/include/config.h
@@ -12,6 +12,7 @@ extern "C" {
 #define _GNU_SOURCE
 
 /* Just assume this for now */
+#define HAVE_ATTRIBUTE_PRINTF  1
 #define HAVE_BUILTIN_EXPECT  1
 
 #ifdef __cplusplus

--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -16,6 +16,38 @@ extern "C" {
 
 
 /*-----------------------------------------------------------------------------
+ * S₀: Errors
+ */
+
+enum s0_error_code {
+    /* Success! */
+    S0_ERROR_NONE = 0,
+    /* Error allocating memory */
+    S0_ERROR_MEMORY_ERROR,
+    /* Cannot overwrite an existing name */
+    S0_ERROR_REDEFINED,
+    /* Something doesn't satisfy a type */
+    S0_ERROR_TYPE_MISMATCH,
+    /* Looking for something that doesn't exist */
+    S0_ERROR_UNDEFINED,
+    /* Something truly weird happened */
+    S0_ERROR_UNKNOWN
+};
+
+/* If any function below returns NULL or -1 to signify an error, you can then
+ * call this function to find outwhat kind of error it was. */
+enum s0_error_code
+s0_error_get_last_code(void);
+
+/* If any function below returns NULL or -1 to signify an error, you can then
+ * call this function to get a human-readable description of the error.  We
+ * retain ownership of the resulting string; you should not try to free the
+ * result. */
+const char *
+s0_error_get_last_description(void);
+
+
+/*-----------------------------------------------------------------------------
  * S₀: Names
  */
 
@@ -169,6 +201,8 @@ s0_environment_delete(struct s0_environment *, const struct s0_name *name);
  * closure, since the entries being closed over are moved from the containing
  * environment into the closure's environment.
  *
+ * All of the names in `set` MUST exist in `src`, and MUST NOT exist in `dest`.
+ *
  * Returns 0 if all of the entries were created successfully; returns -1 if
  * there is an error moving the entries. */
 int
@@ -188,10 +222,9 @@ int
 s0_environment_merge(struct s0_environment *dest, struct s0_environment *src);
 
 /* Applies a renaming (given by a name mapping) to an environment.  The mapping
- * and the environment must be the same size, and there must be an entry in the
- * mapping for every element of the environment.  Returns -1 if these conditions
- * are not met.  Returns ENOMEM if there is an error allocating memory.  Returns
- * 0 if the renaming was successful. */
+ * and the environment MUST be the same size, and there MUST be an entry in the
+ * mapping for every element of the environment.  Returns -1 if there is an
+ * error applying the renaming.  Returns 0 if the renaming was successful. */
 int
 s0_environment_rename(struct s0_environment *,
                       const struct s0_name_mapping *mapping);
@@ -731,8 +764,8 @@ s0_environment_type_extract(struct s0_environment_type *dest,
 /* Applies a renaming (given by a name mapping) to an environment type.  The
  * mapping and the type must be the same size, and there must be an entry in the
  * mapping for every element of the environment type.  Returns -1 if these
- * conditions are not met.  Returns ENOMEM if there is an error allocating
- * memory.  Returns 0 if the renaming was successful. */
+ * conditions are not met, or if there is an error allocating memory.  Returns 0
+ * if the renaming was successful. */
 int
 s0_environment_type_rename(struct s0_environment_type *,
                            const struct s0_name_mapping *mapping);
@@ -866,7 +899,7 @@ s0_yaml_node_is_scalar(const struct s0_yaml_node);
 bool
 s0_yaml_node_is_sequence(const struct s0_yaml_node);
 
-const void *
+const char *
 s0_yaml_node_scalar_content(const struct s0_yaml_node);
 
 size_t

--- a/c/libswanson/yaml.c
+++ b/c/libswanson/yaml.c
@@ -207,10 +207,10 @@ s0_yaml_node_is_sequence(const struct s0_yaml_node node)
     return s0_yaml_node_get_node(node)->type == YAML_SEQUENCE_NODE;
 }
 
-const void *
+const char *
 s0_yaml_node_scalar_content(const struct s0_yaml_node node)
 {
-    return s0_yaml_node_get_node(node)->data.scalar.value;
+    return (char *) s0_yaml_node_get_node(node)->data.scalar.value;
 }
 
 size_t
@@ -873,7 +873,8 @@ s0_load_statement_list(struct s0_yaml_node node,
 
         rc = s0_environment_type_add_statement(type, statement);
         if (unlikely(rc != 0)) {
-            fill_error(node.stream, "Statement has invalid type at %zu:%zu",
+            fill_error(node.stream, "%s\nat %zu:%zu",
+                       s0_error_get_last_description(),
                        s0_yaml_node_get_node(node)->start_mark.line,
                        s0_yaml_node_get_node(node)->start_mark.column);
             s0_statement_free(statement);
@@ -1043,7 +1044,8 @@ s0_load_invocation(struct s0_yaml_node node, struct s0_environment_type *type)
 
     rc = s0_environment_type_add_invocation(type, invocation);
     if (unlikely(rc != 0)) {
-        fill_error(node.stream, "Invocation has invalid type at %zu:%zu",
+        fill_error(node.stream, "%s\nat %zu:%zu",
+                   s0_error_get_last_description(),
                    s0_yaml_node_get_node(node)->start_mark.line,
                    s0_yaml_node_get_node(node)->start_mark.column);
         s0_invocation_free(invocation);

--- a/c/tests/test-cases.h
+++ b/c/tests/test-cases.h
@@ -101,6 +101,18 @@ shorten_filename(const char *filename)
 }
 
 static void
+print_error_message(const char *curr)
+{
+    const char  *nl = strchr(curr, '\n');
+    while (nl != NULL) {
+        printf("# %.*s\n", (int) (nl - curr), curr);
+        curr = nl + 1;
+        nl = strchr(curr, '\n');
+    }
+    printf("# %s\n", curr);
+}
+
+static void
 fail_at(const char *msg, const char *filename, unsigned int line)
 {
     if (!test_case_failed) {
@@ -175,6 +187,7 @@ exit_status(void)
         var = call; \
         if (unlikely(var == NULL)) { \
             fail_at(msg, __FILE__, __LINE__); \
+            print_error_message(s0_error_get_last_description()); \
             return; \
         } \
     } while (0)
@@ -196,11 +209,25 @@ exit_status(void)
     do { \
         if (unlikely((call) != 0)) { \
             fail_at(msg, __FILE__, __LINE__); \
+            print_error_message(s0_error_get_last_description()); \
             return; \
         } \
     } while (0)
 
 #define check0(call)  check0_with_msg(call, "Error occurred")
+
+#define checkx0_with_msg(call, msg) \
+    do { \
+        if (unlikely((call) == 0)) { \
+            fail_at(msg, __FILE__, __LINE__); \
+            return; \
+        } else { \
+            printf("# Expected error occurred:\n"); \
+            print_error_message(s0_error_get_last_description()); \
+        } \
+    } while (0)
+
+#define checkx0(call)  checkx0_with_msg(call, "Error should have occurred")
 
 #define check_nonnull_with_msg(call, msg) \
     do { \

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -46,14 +46,16 @@ entity_type(const char *str)
 
     node = s0_yaml_stream_parse_document(stream);
     if (s0_yaml_node_is_error(node)) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
         s0_yaml_stream_free(stream);
         return NULL;
     }
 
     type = s0_yaml_document_parse_entity_type(node);
     if (type == NULL) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
     }
     s0_yaml_stream_free(stream);
     return type;
@@ -73,14 +75,16 @@ environment_type(const char *str)
 
     node = s0_yaml_stream_parse_document(stream);
     if (s0_yaml_node_is_error(node)) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
         s0_yaml_stream_free(stream);
         return NULL;
     }
 
     type = s0_yaml_document_parse_environment_type(node);
     if (type == NULL) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
     }
     s0_yaml_stream_free(stream);
     return type;
@@ -103,14 +107,16 @@ load_block(const char *str)
 
     node = s0_yaml_stream_parse_document(stream);
     if (s0_yaml_node_is_error(node)) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
         s0_yaml_stream_free(stream);
         return NULL;
     }
 
     closure = s0_yaml_document_parse_module(node);
     if (closure == NULL) {
-        fail(s0_yaml_stream_last_error(stream));
+        fail("Error loading YAML");
+        print_error_message(s0_yaml_stream_last_error(stream));
         s0_yaml_stream_free(stream);
         return NULL;
     }
@@ -1517,33 +1523,6 @@ TEST_CASE("{a:⋄,b:⋄}[a→b,b→a] == {a:⋄,b:⋄}") {
     s0_environment_free(env);
 }
 
-TEST_CASE("{a:⋄}[a→b,c→d] is invalid") {
-    struct s0_environment  *env;
-    struct s0_name  *name;
-    struct s0_entity  *atom;
-    struct s0_name_mapping  *mapping;
-    struct s0_name  *from;
-    struct s0_name  *to;
-    /* Construct {a:⋄} */
-    check_alloc(env, s0_environment_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check_alloc(atom, s0_atom_new());
-    check0(s0_environment_add(env, name, atom));
-    /* Construct [a→b,c→d] */
-    check_alloc(mapping, s0_name_mapping_new());
-    check_alloc(from, s0_name_new_str("a"));
-    check_alloc(to, s0_name_new_str("b"));
-    check0(s0_name_mapping_add(mapping, from, to));
-    check_alloc(from, s0_name_new_str("c"));
-    check_alloc(to, s0_name_new_str("d"));
-    check0(s0_name_mapping_add(mapping, from, to));
-    /* Verify that we can't apply renaming */
-    check(s0_environment_rename(env, mapping) != 0);
-    /* Free everything */
-    s0_name_mapping_free(mapping);
-    s0_environment_free(env);
-}
-
 /*-----------------------------------------------------------------------------
  * S₀: Entity types: Any
  */
@@ -2863,34 +2842,6 @@ TEST_CASE("can extract entries from environment type") {
     s0_environment_type_free(dest);
 }
 
-TEST_CASE("cannot extract duplicate entries from environment type") {
-    struct s0_environment_type  *src;
-    struct s0_environment_type  *dest;
-    struct s0_name  *name;
-    struct s0_entity_type  *etype;
-    struct s0_name_set  *set;
-
-    /* Construct ⦃a:*⦄ */
-    check_alloc(src, s0_environment_type_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check_alloc(etype, s0_any_entity_type_new());
-    check0(s0_environment_type_add(src, name, etype));
-
-    /* Extract `a` into a separate type that already contains `a` */
-    check_alloc(dest, s0_environment_type_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check_alloc(etype, s0_any_entity_type_new());
-    check0(s0_environment_type_add(dest, name, etype));
-    check_alloc(set, s0_name_set_new());
-    check_alloc(name, s0_name_new_str("a"));
-    check0(s0_name_set_add(set, name));
-    check(s0_environment_type_extract(dest, src, set) == -1);
-    s0_name_set_free(set);
-
-    s0_environment_type_free(src);
-    s0_environment_type_free(dest);
-}
-
 TEST_CASE("cannot get deleted entries from environment type") {
     struct s0_environment_type  *type;
     struct s0_name  *name;
@@ -3563,7 +3514,7 @@ TEST_CASE("⦃a:*⦄[a→b,c→d] is invalid") {
     check_alloc(to, s0_name_new_str("d"));
     check0(s0_name_mapping_add(mapping, from, to));
     /* Verify that we can't apply renaming */
-    check(s0_environment_type_rename(type, mapping) != 0);
+    checkx0(s0_environment_type_rename(type, mapping));
     /* Free everything */
     s0_name_mapping_free(mapping);
     s0_environment_type_free(type);


### PR DESCRIPTION
We now fill in useful error messages during type checking, and in some other less likely situations (like memory allocation errors).