### PR TITLE
Type-check the closed-over set of a closure

### DIFF
--- a/c/include/swanson.h
+++ b/c/include/swanson.h
@@ -749,6 +749,15 @@ struct s0_entity_type *
 s0_environment_type_delete(struct s0_environment_type *,
                            const struct s0_name *name);
 
+/* Creates copies of each entry in `src`, adding them to `dest`.  There MUST NOT
+ * be any entries in `src` that are already in `dest`.
+ *
+ * Returns 0 if all of the entries were copied successfully; returns -1 if there
+ * is an error moving the entries. */
+int
+s0_environment_type_extend(struct s0_environment_type *dest,
+                           const struct s0_environment_type *src);
+
 /* Extracts entries from `src`, moving them into `dest`.  The entries to extract
  * are given by a name set.  This is used for closure sets when constructing a
  * closure, since the entries described by the type are moved from the

--- a/c/libswanson/s0.c
+++ b/c/libswanson/s0.c
@@ -2864,6 +2864,43 @@ s0_environment_type_delete(struct s0_environment_type *type,
 }
 
 int
+s0_environment_type_extend(struct s0_environment_type *dest,
+                           const struct s0_environment_type *src)
+{
+    size_t  i;
+
+#if !defined(NDEBUG)
+    for (i = 0; i < src->size; i++) {
+        const struct s0_name  *name = src->entries[i].name;
+        assert(s0_environment_type_get(dest, name) == NULL);
+    }
+#endif
+
+    for (i = 0; i < src->size; i++) {
+        int  rc;
+        struct s0_name  *name_copy;
+        struct s0_entity_type  *etype_copy;
+
+        name_copy = s0_name_new_copy(src->entries[i].name);
+        if (unlikely(name_copy == NULL)) {
+            return -1;
+        }
+
+        etype_copy = s0_entity_type_new_copy(src->entries[i].type);
+        if (unlikely(etype_copy == NULL)) {
+            s0_name_free(name_copy);
+            return -1;
+        }
+
+        rc = s0_environment_type_add(dest, name_copy, etype_copy);
+        if (unlikely(rc != 0)) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int
 s0_environment_type_extract(struct s0_environment_type *dest,
                             struct s0_environment_type *src,
                             const struct s0_name_set *set)

--- a/c/tests/test-swanson.c
+++ b/c/tests/test-swanson.c
@@ -2795,6 +2795,44 @@ TEST_CASE("can delete entries from environment type") {
     s0_environment_type_free(type);
 }
 
+TEST_CASE("can extend an environment type with a copy of another") {
+    struct s0_environment_type  *src;
+    struct s0_environment_type  *dest;
+    struct s0_name  *name;
+    struct s0_entity_type  *etype;
+    /* Construct dest = ⦃a:*⦄ */
+    check_alloc(dest, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("a"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(dest, name, etype));
+    /* Construct src = ⦃b:*⦄ */
+    check_alloc(src, s0_environment_type_new());
+    check_alloc(name, s0_name_new_str("b"));
+    check_alloc(etype, s0_any_entity_type_new());
+    check0(s0_environment_type_add(src, name, etype));
+    /* Extend dest with src */
+    check0(s0_environment_type_extend(dest, src));
+    /* Verify that dest == ⦃a:*,b:*⦄ */
+    check(s0_environment_type_size(dest) == 2);
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_get(dest, name) != NULL);
+    s0_name_free(name);
+    check_alloc(name, s0_name_new_str("b"));
+    check(s0_environment_type_get(dest, name) != NULL);
+    s0_name_free(name);
+    /* Verify that src == ⦃b:*⦄ */
+    check(s0_environment_type_size(src) == 1);
+    check_alloc(name, s0_name_new_str("a"));
+    check(s0_environment_type_get(src, name) == NULL);
+    s0_name_free(name);
+    check_alloc(name, s0_name_new_str("b"));
+    check(s0_environment_type_get(src, name) != NULL);
+    s0_name_free(name);
+    /* Free everything */
+    s0_environment_type_free(src);
+    s0_environment_type_free(dest);
+}
+
 TEST_CASE("can extract entries from environment type") {
     struct s0_environment_type  *src;
     struct s0_environment_type  *dest;

--- a/tests/s0/parsing/create-closure.yaml
+++ b/tests/s0/parsing/create-closure.yaml
@@ -33,6 +33,50 @@ module:
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
+!s0!successful-parse
+name: create-closure can close over an environment entry
+module:
+  inputs:
+    exit: !s0!closure
+      branches:
+        return:
+          x: !s0!any {}
+    y: !s0!any {}
+  statements:
+    - !s0!create-closure
+      dest: x
+      # We close over `y`, removing it from the containing environment.
+      closed-over: [y]
+      branches:
+        body:
+          inputs:
+            exit: !s0!closure
+              branches:
+                return:
+                  # We need to make sure our `exit` continuation can discharge
+                  # the `y` that we've closed over.
+                  y: !s0!any {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: exit
+            branch: return
+            parameters:
+              # Inside of the closure, `y` is available, so we need to hand it
+              # off to `exit` to discharge it.
+              y: y
+  invocation:
+    !s0!invoke-closure
+    src: exit
+    branch: return
+    parameters:
+      # Since we closed over `y` above, it should not be part of the parameter
+      # list here, since it's been moved from our environment into the closure's
+      # internal closed-over environment.
+      x: x
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
 !s0!invalid-parse
 name: create-closure needs a destination
 module:
@@ -268,8 +312,7 @@ module:
   statements:
     - !s0!create-closure
       dest: x
-      closed-over:
-        - x
+      closed-over: []
       branches:
         body:
           inputs:

--- a/tests/s0/parsing/invoke-closure.yaml
+++ b/tests/s0/parsing/invoke-closure.yaml
@@ -16,6 +16,34 @@ module:
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
+!s0!successful-parse
+name: invoke-closure can call a closure in a closed-over set
+module:
+  inputs:
+    second: !s0!closure
+      branches:
+        body: {}
+  statements:
+    - !s0!create-closure
+      dest: first
+      closed-over: [second]
+      branches:
+        body:
+          inputs: {}
+          statements: []
+          invocation:
+            !s0!invoke-closure
+            src: second
+            branch: body
+            parameters: {}
+  invocation:
+    !s0!invoke-closure
+    src: first
+    branch: body
+    parameters: {}
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
 !s0!invalid-parse
 name: invoke-closure needs a source
 module:

--- a/tests/s0/parsing/invoke-method.yaml
+++ b/tests/s0/parsing/invoke-method.yaml
@@ -18,6 +18,36 @@ module:
 
 %TAG !s0! tag:swanson-lang.org,2016:
 ---
+!s0!successful-parse
+name: invoke-method can call a method in a closed-over set
+module:
+  inputs:
+    second: !s0!object
+      id: !s0!method
+        inputs:
+          self: !s0!any {}
+  statements:
+    - !s0!create-closure
+      dest: first
+      closed-over: [second]
+      branches:
+        body:
+          inputs: {}
+          statements: []
+          invocation:
+            !s0!invoke-method
+            src: second
+            method: id
+            parameters:
+              second: self
+  invocation:
+    !s0!invoke-closure
+    src: first
+    branch: body
+    parameters: {}
+
+%TAG !s0! tag:swanson-lang.org,2016:
+---
 !s0!invalid-parse
 name: invoke-method needs a source
 module:


### PR DESCRIPTION
Right now we're not including the contents of a closure's closed-over set in the environment when type-checking it.  That gives us incorrect parse errors if you try to use anything that you've closed over.